### PR TITLE
Use WORKSPACE instead of MODULE.bazel.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,8 @@
 #     elinux_armhf:    Embedded Linux options for armhf (ARMv7) CPU support.
 #
 # Default build options. These are applied first and unconditionally.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
 
 # For projects which use TensorFlow as part of a Bazel build process, putting
 # nothing in a bazelrc will default to a monolithic build. The following line

--- a/BUILD.sentencepiece
+++ b/BUILD.sentencepiece
@@ -69,6 +69,6 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings:str_format",
-	"@darts_clone//:darts_clone",
+        "@darts_clone//:darts_clone",
     ],
 )

--- a/PATCH.sentencepiece
+++ b/PATCH.sentencepiece
@@ -1,0 +1,77 @@
+--- sentencepiece_processor.h	2025-04-27 15:47:21.057722872 -0700
++++ sentencepiece_processor.h	2025-04-27 15:50:12.601047364 -0700
+@@ -22,6 +22,8 @@
+ #include <utility>
+ #include <vector>
+ 
++#include "absl/status/status.h"
++
+ #ifndef SWIG
+ namespace absl {
+ using std::string_view;
+@@ -30,50 +32,8 @@
+ 
+ namespace sentencepiece {
+ namespace util {
+-
+-enum class StatusCode : int {
+-  kOk = 0,
+-  kCancelled = 1,
+-  kUnknown = 2,
+-  kInvalidArgument = 3,
+-  kDeadlineExceeded = 4,
+-  kNotFound = 5,
+-  kAlreadyExists = 6,
+-  kPermissionDenied = 7,
+-  kResourceExhausted = 8,
+-  kFailedPrecondition = 9,
+-  kAborted = 10,
+-  kOutOfRange = 11,
+-  kUnimplemented = 12,
+-  kInternal = 13,
+-  kUnavailable = 14,
+-  kDataLoss = 15,
+-  kUnauthenticated = 16,
+-};
+-
+-class Status {
+- public:
+-  Status();
+-  ~Status();
+-  Status(StatusCode code, absl::string_view error_message);
+-  Status(const Status &s);
+-  void operator=(const Status &s);
+-  bool operator==(const Status &s) const;
+-  bool operator!=(const Status &s) const;
+-  inline bool ok() const { return rep_ == nullptr; }
+-
+-  void set_error_message(const char *str);
+-  const char *error_message() const;
+-  const char *message() const { return error_message(); }
+-  StatusCode code() const;
+-  std::string ToString() const;
+-
+-  void IgnoreError();
+-
+- private:
+-  struct Rep;
+-  std::unique_ptr<Rep> rep_;
+-};
++using StatusCode = absl::StatusCode;
++using Status = absl::Status;
+ }  // namespace util
+ 
+ // SentencePieceProcessor:
+
+--- common.h	2025-04-27 15:55:22.642953123 -0700
++++ common.h	2025-04-27 16:02:22.377904469 -0700
+@@ -94,7 +94,7 @@
+   ~Die() {
+     std::cerr << std::endl;
+     if (die_) {
+-      Abort();
++      exit(-1);
+     }
+   }
+   int operator&(std::ostream &) { return 0; }
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,10 +16,18 @@ http_archive(
 # Tensorflow
 http_archive(
     name = "org_tensorflow",
-    # 2025-03-04 when lite_headers_filegroup got public.
-    url = "https://github.com/tensorflow/tensorflow/archive/f61e140e1610f155e34908b36790bb1c8e2341c3.tar.gz",
+    patch_cmds = [
+        # Update XNNPACK latest for litert.
+        "sed -i -e 's|24794834234a7926d2f553d34e84204c8ac99dfd|d10bb18be825fab45f43e3958238f0df61101426|g' tensorflow/workspace2.bzl",  # git SHA-1 tag
+        "sed -i -e 's|04291b4c49693988f8c95d07968f6f3da3fd89d85bd9e4e26f73abbdfd7a8a45|5f55c355247e380e26d12758d74a22a2fc8e427b87813e998ae44e009cb48f5f|g' tensorflow/workspace2.bzl",  # SHA256
+        # Update pthreadpool latest for XNNPACK.
+        "sed -i -e 's|b1aee199d54003fb557076a201bcac3398af580b|bd09d5ca9155863fc47a9cbf0df1908ef9d8cad2|g' tensorflow/workspace2.bzl",  # git SHA-1 tag
+        "sed -i -e 's|215724985c4845cdcadcb5f26a2a8777943927bb5a172a00e7716fe16a6f3c1b|034a78c0ef8cce1cc2ac4c90234bbb04c334000e68f7813db91ea42766870925|g' tensorflow/workspace2.bzl",  # SHA256
+    ],
     sha256 = "c18d887db64ec045681c61923b74365dd7231d9731e5be3055e60bc809eb61f4",
     strip_prefix = "tensorflow-f61e140e1610f155e34908b36790bb1c8e2341c3",
+    # 2025-03-04 when lite_headers_filegroup got public.
+    url = "https://github.com/tensorflow/tensorflow/archive/f61e140e1610f155e34908b36790bb1c8e2341c3.tar.gz",
 )
 
 # Initialize the TensorFlow repository and all dependencies.
@@ -80,13 +88,6 @@ load("@org_tensorflow//tensorflow:workspace0.bzl", "tf_workspace0")
 
 tf_workspace0()
 
-#load(
-#    "@local_xla//third_party/py:python_wheel.bzl",
-#    "python_wheel_version_suffix_repository",
-#)
-#
-#python_wheel_version_suffix_repository(name = "tf_wheel_version_suffix")
-
 load(
     "@local_tsl//third_party/gpus/cuda/hermetic:cuda_json_init_repository.bzl",
     "cuda_json_init_repository",
@@ -134,10 +135,6 @@ load(
 
 nccl_configure(name = "local_config_nccl")
 
-#load("//third_party/tqdm:workspace.bzl", tqdm = "repo")
-#
-#tqdm()
-
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
@@ -171,54 +168,49 @@ load("@rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 
 kt_register_toolchains()  # to use the default toolchain, otherwise see toolchains below
 
-# VENDOR SDKS ######################################################################################
-
-# QUALCOMM ---------------------------------------------------------------------------------------
-
-# The actual macro call will be set during configure for now.
-#load("//third_party/qairt:workspace.bzl", "qairt")
-#
-#qairt()
-
 # Same one downloaded by tensorflow, but refer contrib/minizip.
 http_archive(
     name = "minizip",
-    url = "https://zlib.net/fossils/zlib-1.3.1.tar.gz",
-    sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
-    strip_prefix = "zlib-1.3.1/contrib/minizip",
     add_prefix = "minizip",
     build_file = "@//:BUILD.minizip",
+    sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
+    strip_prefix = "zlib-1.3.1/contrib/minizip",
+    url = "https://zlib.net/fossils/zlib-1.3.1.tar.gz",
 )
 
 http_archive(
     name = "sentencepiece",
-    url = "https://github.com/google/sentencepiece/archive/refs/tags/v0.2.0.tar.gz",
-    sha256 = "9970f0a0afee1648890293321665e5b2efa04eaec9f1671fcf8048f456f5bb86",
-    strip_prefix = "sentencepiece-0.2.0/src",
+    build_file = "@//:BUILD.sentencepiece",
     patch_cmds = [
         # Empty config.h seems enough.
-	"touch config.h",
+        "touch config.h",
         # Replace third_party/absl/ with absl/ in *.h and *.cc files.
         "sed -i -e 's|#include \"third_party/absl/|#include \"absl/|g' *.h *.cc",
-	# Replace third_party/darts_clone/ with include/ in *.h and *.cc files.
+        # Replace third_party/darts_clone/ with include/ in *.h and *.cc files.
         "sed -i -e 's|#include \"third_party/darts_clone/|#include \"include/|g' *.h *.cc",
     ],
-    build_file = "@//:BUILD.sentencepiece",
+    patches = ["@//:PATCH.sentencepiece"],
+    sha256 = "9970f0a0afee1648890293321665e5b2efa04eaec9f1671fcf8048f456f5bb86",
+    strip_prefix = "sentencepiece-0.2.0/src",
+    url = "https://github.com/google/sentencepiece/archive/refs/tags/v0.2.0.tar.gz",
 )
 
 http_archive(
     name = "darts_clone",
-    url = "https://github.com/s-yata/darts-clone/archive/e40ce4627526985a7767444b6ed6893ab6ff8983.tar.gz",
+    build_file = "@//:BUILD.darts_clone",
     sha256 = "4a562824ec2fbb0ef7bd0058d9f73300173d20757b33bb69baa7e50349f65820",
     strip_prefix = "darts-clone-e40ce4627526985a7767444b6ed6893ab6ff8983",
-    build_file = "@//:BUILD.darts_clone",
+    url = "https://github.com/s-yata/darts-clone/archive/e40ce4627526985a7767444b6ed6893ab6ff8983.tar.gz",
 )
 
 http_archive(
     name = "litert",
-    # 2025-04-25. Tags don't include litert/.
-    url = "https://github.com/google-ai-edge/LiteRT/archive/5a816dca891292a96e4562f879cd74c1e3dd851e.tar.gz",
+    patch_cmds = [
+        # Update visibility to public for litert/c/BUILD and litert/cc/BUILD.
+        "sed -i -e 's|//litert:litert_stable_abi_users|//visibility:public|g' litert/c/BUILD litert/cc/BUILD",
+    ],
     sha256 = "1c5745dd56c968da23e48b8194914e5154a71d40d5aef6613e2d6ac9261f852a",
     strip_prefix = "LiteRT-5a816dca891292a96e4562f879cd74c1e3dd851e",
+    # 2025-04-25. Tags don't include litert/.
+    url = "https://github.com/google-ai-edge/LiteRT/archive/5a816dca891292a96e4562f879cd74c1e3dd851e.tar.gz",
 )
-

--- a/runtime/executor/llm_litert_compiled_model_executor.cc
+++ b/runtime/executor/llm_litert_compiled_model_executor.cc
@@ -318,14 +318,6 @@ absl::StatusOr<std::vector<int>> LlmLiteRtCompiledModelExecutor::SampleLogits(
   return *ids;
 }
 
-absl::Status LlmLiteRtCompiledModelExecutor::Reset() {
-  current_step_ = 0;
-  next_input_token_id_ = -1;
-  processed_tokens_.clear();
-  cpu_sampler_.reset();
-  return absl::OkStatus();
-}
-
 absl::StatusOr<int> LlmLiteRtCompiledModelExecutor::GetVocabSize() {
   if (!decode_output_buffers_.contains(signatures_.output_logits)) {
     return absl::NotFoundError("Output logits info not found.");

--- a/runtime/executor/llm_litert_compiled_model_executor.h
+++ b/runtime/executor/llm_litert_compiled_model_executor.h
@@ -79,29 +79,6 @@ class LlmLiteRtCompiledModelExecutor : public ::litert::lm::LlmExecutor {
     return "LiteRT Compiled Model";
   }
 
-  // Updates the runtime configuration.
-  absl::Status UpdateRuntimeConfig(
-      const ::litert::lm::RuntimeConfig& runtime_config) override {
-    ABSL_LOG(WARNING)
-        << "UpdateRuntimeConfig doesn't take effect for LiteRT Compiled Model.";
-    return absl::OkStatus();
-  }
-
-  // Gets the current step of the executor.
-  // Public API, the return value is the current step that user expects (e.g.
-  // users prefill 100 tokens, then they expect the current step to be 100). It
-  // is different from the internal current step.
-  absl::StatusOr<int> GetCurrentStep() const override {
-    return current_step_ + (next_input_token_id_ == -1 ? 0 : 1);
-  }
-
-  absl::StatusOr<const std::vector<int>*> GetProcessedTokens() const override {
-    return &processed_tokens_;
-  }
-
-  // Resets all of the internal states.
-  absl::Status Reset() override;
-
   absl::StatusOr<int> GetVocabSize() override;
 
  protected:


### PR DESCRIPTION
Use WORKSPACE instead of MODULE.bazel.

- MODULE.bazel is a new way to setup dependencies.
- Follow litert and tensorflow to use WORKSPACE for easier setup.
