### PR TITLE
Fix LC_UUID missing error on macOS by patching build_bazel_apple_support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,6 +116,18 @@ load("@cxxbridge_cmd_deps//:defs.bzl", cxxbridge_cmd_deps = "crate_repositories"
 
 cxxbridge_cmd_deps()
 
+# Apple Support (must be declared before TensorFlow to apply our patch)
+# This fixes the LC_UUID missing error on macOS by removing -Wl,-no_uuid flag
+http_archive(
+    name = "build_bazel_apple_support",
+    patch_cmds = [
+        # Remove -Wl,-no_uuid flag to fix LC_UUID missing error on macOS
+        "sed -i.bak 's/\"-Wl,-no_uuid\",//' crosstool/osx_cc_configure.bzl || true",
+    ],
+    sha256 = "1ae6fcf983cff3edab717636f91ad0efff2e5ba75607fdddddfd6ad0dbdfaf10",
+    url = "https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz",
+)
+
 # TensorFlow
 http_archive(
     name = "org_tensorflow",


### PR DESCRIPTION
## Summary
This PR fixes the `LC_UUID missing load command` build error on macOS by patching the `build_bazel_apple_support` repository.

## Problem
When building with Bazel on macOS, the build fails with the following error:
```
dyld[xxxx]: missing LC_UUID load command in .../external/local_config_apple_cc/wrapped_clang
```
This occurs because `build_bazel_apple_support` builds the `wrapped_clang` binary with the `-Wl,-no_uuid` linker flag, which prevents the LC_UUID load command from being generated. macOS's dynamic linker (dyld) rejects binaries without this load command.

## Solution
Declare `build_bazel_apple_support` before TensorFlow in the WORKSPACE file and apply a patch that removes the `-Wl,-no_uuid` linker flag from `crosstool/osx_cc_configure.bzl`.

## Changes
- Added `http_archive` declaration for `build_bazel_apple_support` with `patch_cmds` to remove the problematic linker flag
- Placed the declaration before TensorFlow to ensure our patched version is used instead of TensorFlow's

## Testing
- Verified that `bazel build //runtime/...` completes successfully on macOS