### PR TITLE
Fix LC_UUID missing error on macOS

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,6 +44,16 @@ http_archive(
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
 
+# Apple Support - MUST be declared BEFORE rules_rust_dependencies() to override rules_rust's old version
+# This fixes the LC_UUID missing error on macOS by patching out -Wl,-no_uuid flag
+http_archive(
+    name = "build_bazel_apple_support",
+    patch_args = ["-p1"],
+    patches = ["//patches:apple_support_no_uuid.patch"],
+    sha256 = "b53f6491e742549f13866628ddffcc75d1f3b2d6987dc4f14a16b242113c890b",
+    url = "https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz",
+)
+
 rules_rust_dependencies()
 
 rust_register_toolchains(

--- a/patches/BUILD
+++ b/patches/BUILD
@@ -1,0 +1,1 @@
+exports_files(["apple_support_no_uuid.patch"])

--- a/patches/apple_support_no_uuid.patch
+++ b/patches/apple_support_no_uuid.patch
@@ -1,0 +1,10 @@
+--- a/crosstool/osx_cc_configure.bzl
++++ b/crosstool/osx_cc_configure.bzl
+@@ -103,7 +103,6 @@
+         "-arch",
+         "x86_64",
+         "-Wl,-no_adhoc_codesign",
+-        "-Wl,-no_uuid",
+         "-O3",
+         "-o",
+         out_name,


### PR DESCRIPTION
## Summary
- Fix `dyld: missing LC_UUID load command` error when building on macOS
- Declare `build_bazel_apple_support` before `rules_rust_dependencies()` to override the internally defined old version
- Apply patch to remove `-Wl,-no_uuid` linker flag from `osx_cc_configure.bzl`

## Problem
On macOS, the build fails with:
dyld[xxxx]: missing LC_UUID load command in .../wrapped_clang

## Root Cause
1. `rules_rust` internally declares `build_bazel_apple_support` version 1.17.1 in `rust/repositories.bzl`
2. This version contains `-Wl,-no_uuid` linker flag in `crosstool/osx_cc_configure.bzl`
3. This flag prevents the `wrapped_clang` binary from having the `LC_UUID` load command
4. macOS `dyld` rejects binaries without `LC_UUID`

If `build_bazel_apple_support` is declared after `rules_rust_dependencies()` is called, the declaration is skipped with message: "Warning: skipping import of repository 'build_bazel_apple_support' because it already exists."

## Solution
- Declare `build_bazel_apple_support` **before** `rules_rust_dependencies()` call in WORKSPACE
- Apply a patch that removes the `-Wl,-no_uuid` flag