### PR TITLE
feat: session-aware lora, & a memory-efficient zeroth order optimizer

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -130,6 +130,7 @@ maven_install(
     name = "maven",
     artifacts = [
         "com.google.code.gson:gson:2.13.2",
+        "junit:junit:4.13.2",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.9.0",
         "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0",
     ],

--- a/c/engine.cc
+++ b/c/engine.cc
@@ -196,6 +196,26 @@ void litert_lm_session_config_set_sampler_params(
   }
 }
 
+void litert_lm_session_config_set_lora_id(LiteRtLmSessionConfig* config,
+                                          int32_t lora_id) {
+  if (config && config->config) {
+    if (lora_id >= 0) {
+      config->config->SetLoraId(static_cast<uint32_t>(lora_id));
+    } else {
+      config->config->SetLoraId(std::nullopt);
+    }
+  }
+}
+
+int32_t litert_lm_session_config_get_lora_id(
+    const LiteRtLmSessionConfig* config) {
+  if (!config || !config->config) {
+    return -1;
+  }
+  auto lora_id = config->config->GetLoraId();
+  return lora_id.has_value() ? static_cast<int32_t>(*lora_id) : -1;
+}
+
 void litert_lm_session_config_delete(LiteRtLmSessionConfig* config) {
   delete config;
 }

--- a/c/engine.h
+++ b/c/engine.h
@@ -110,6 +110,21 @@ LITERT_LM_C_API_EXPORT
 void litert_lm_session_config_set_sampler_params(
     LiteRtLmSessionConfig* config, const LiteRtLmSamplerParams* sampler_params);
 
+// Sets the LoRA adapter ID for this session config.
+// Sessions created with this config will use the specified LoRA adapter.
+// @param config The config to modify.
+// @param lora_id The LoRA adapter ID to use. Pass -1 to clear (use base model).
+LITERT_LM_C_API_EXPORT
+void litert_lm_session_config_set_lora_id(LiteRtLmSessionConfig* config,
+                                          int32_t lora_id);
+
+// Gets the LoRA adapter ID from this session config.
+// @param config The config to query.
+// @return The LoRA adapter ID, or -1 if no LoRA is set.
+LITERT_LM_C_API_EXPORT
+int32_t litert_lm_session_config_get_lora_id(
+    const LiteRtLmSessionConfig* config);
+
 // Destroys a LiteRT LM Session Config.
 // @param config The config to destroy.
 LITERT_LM_C_API_EXPORT

--- a/c/engine_test.cc
+++ b/c/engine_test.cc
@@ -144,6 +144,54 @@ TEST(EngineCTest, CreateSessionConfigWithNoSamplerParams) {
             litert::lm::proto::SamplerParameters::TYPE_UNSPECIFIED);
 }
 
+TEST(EngineCTest, SessionConfigLoraIdDefaultIsUnset) {
+  SessionConfigPtr config(litert_lm_session_config_create(),
+                          &litert_lm_session_config_delete);
+  ASSERT_NE(config, nullptr);
+
+  // Default should be -1 (no LoRA).
+  EXPECT_EQ(litert_lm_session_config_get_lora_id(config.get()), -1);
+  EXPECT_EQ(config->config->GetLoraId(), std::nullopt);
+}
+
+TEST(EngineCTest, SessionConfigSetAndGetLoraId) {
+  SessionConfigPtr config(litert_lm_session_config_create(),
+                          &litert_lm_session_config_delete);
+  ASSERT_NE(config, nullptr);
+
+  // Set a LoRA ID.
+  litert_lm_session_config_set_lora_id(config.get(), 42);
+  EXPECT_EQ(litert_lm_session_config_get_lora_id(config.get()), 42);
+  EXPECT_EQ(config->config->GetLoraId(), std::optional<uint32_t>(42));
+
+  // Change the LoRA ID.
+  litert_lm_session_config_set_lora_id(config.get(), 99);
+  EXPECT_EQ(litert_lm_session_config_get_lora_id(config.get()), 99);
+  EXPECT_EQ(config->config->GetLoraId(), std::optional<uint32_t>(99));
+
+  // Clear LoRA ID with -1.
+  litert_lm_session_config_set_lora_id(config.get(), -1);
+  EXPECT_EQ(litert_lm_session_config_get_lora_id(config.get()), -1);
+  EXPECT_EQ(config->config->GetLoraId(), std::nullopt);
+}
+
+TEST(EngineCTest, SessionConfigLoraIdZeroIsValid) {
+  SessionConfigPtr config(litert_lm_session_config_create(),
+                          &litert_lm_session_config_delete);
+  ASSERT_NE(config, nullptr);
+
+  // LoRA ID 0 is a valid ID (first adapter).
+  litert_lm_session_config_set_lora_id(config.get(), 0);
+  EXPECT_EQ(litert_lm_session_config_get_lora_id(config.get()), 0);
+  EXPECT_EQ(config->config->GetLoraId(), std::optional<uint32_t>(0));
+}
+
+TEST(EngineCTest, SessionConfigLoraIdNullConfigHandling) {
+  // Should not crash with null config.
+  litert_lm_session_config_set_lora_id(nullptr, 42);
+  EXPECT_EQ(litert_lm_session_config_get_lora_id(nullptr), -1);
+}
+
 TEST(EngineCTest, CreateConversationConfig) {
   // 1. Create an engine.
   const std::string task_path = GetTestdataPath(

--- a/kotlin/java/com/google/ai/edge/litertlm/BUILD
+++ b/kotlin/java/com/google/ai/edge/litertlm/BUILD
@@ -31,10 +31,26 @@ kt_jvm_library(
 
 kt_android_library(
     name = "litertlm-android",
-    srcs = glob(["*.kt"]),
+    srcs = glob(
+        ["*.kt"],
+        exclude = ["*Test.kt"],
+    ),
     deps = [
         "@rules_kotlin//kotlin/compiler:kotlin-reflect",
         "@maven//:com_google_code_gson_gson",
         "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_android"
     ],
+)
+
+kt_jvm_library(
+    name = "config_test_lib",
+    srcs = ["ConfigTest.kt"],
+    deps = [":litertlm-jvm"],
+)
+
+java_test(
+    name = "config_test",
+    main_class = "com.google.ai.edge.litertlm.ConfigTest",
+    use_testrunner = False,
+    runtime_deps = [":config_test_lib"],
 )

--- a/kotlin/java/com/google/ai/edge/litertlm/Config.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/Config.kt
@@ -65,6 +65,8 @@ data class EngineConfig(
  *   default values.
  * @property systemMessage The system message to be used in the conversation. If set, it will
  *   prepend to [initialMessages].
+ * @property loraId The LoRA adapter ID to use for this conversation. Pass `null` to use the base
+ *   model without any adapter. LoRA IDs are assigned when adapters are loaded into the engine.
  */
 data class ConversationConfig(
   val systemInstruction: Contents? = null,
@@ -74,7 +76,14 @@ data class ConversationConfig(
   val samplerConfig: SamplerConfig? = null,
   @Deprecated("Use systemInstruction instead. e.g., systemInstrction = Contents.of(\"Be helpful\")")
   val systemMessage: Message? = null,
-)
+  val loraId: Int? = null,
+) {
+  init {
+    require(loraId == null || loraId >= 0) {
+      "loraId must be non-negative or null, got $loraId"
+    }
+  }
+}
 
 /**
  * Configuration for the sampling process.
@@ -102,5 +111,16 @@ data class SamplerConfig(
  *
  * @property samplerConfig Configuration for the sampling process. If `null`, then uses the engine's
  *   default values.
+ * @property loraId The LoRA adapter ID to use for this session. Pass `null` to use the base model
+ *   without any adapter. LoRA IDs are assigned when adapters are loaded into the engine.
  */
-data class SessionConfig(val samplerConfig: SamplerConfig? = null)
+data class SessionConfig(
+  val samplerConfig: SamplerConfig? = null,
+  val loraId: Int? = null
+) {
+  init {
+    require(loraId == null || loraId >= 0) {
+      "loraId must be non-negative or null, got $loraId"
+    }
+  }
+}

--- a/kotlin/java/com/google/ai/edge/litertlm/ConfigTest.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/ConfigTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.ai.edge.litertlm
+
+/** Simple test runner for config validation. */
+object ConfigTest {
+
+  private var testsPassed = 0
+  private var testsFailed = 0
+
+  private fun test(name: String, block: () -> Unit) {
+    try {
+      block()
+      testsPassed++
+      println("✓ $name")
+    } catch (e: Throwable) {
+      testsFailed++
+      println("✗ $name: ${e.message}")
+    }
+  }
+
+  private fun assertEquals(expected: Any?, actual: Any?) {
+    if (expected != actual) {
+      throw AssertionError("Expected <$expected> but was <$actual>")
+    }
+  }
+
+  private fun assertNull(value: Any?) {
+    if (value != null) {
+      throw AssertionError("Expected null but was <$value>")
+    }
+  }
+
+  private inline fun <reified T : Throwable> assertThrows(block: () -> Unit) {
+    try {
+      block()
+      throw AssertionError("Expected ${T::class.simpleName} to be thrown")
+    } catch (e: Throwable) {
+      if (e !is T) {
+        throw AssertionError("Expected ${T::class.simpleName} but got ${e::class.simpleName}: ${e.message}")
+      }
+    }
+  }
+
+  @JvmStatic
+  fun main(args: Array<String>) {
+    println("Running ConfigTest...")
+    println()
+
+    test("sessionConfig_defaultLoraIdIsNull") {
+      val config = SessionConfig()
+      assertNull(config.loraId)
+    }
+
+    test("sessionConfig_loraIdZeroIsValid") {
+      val config = SessionConfig(loraId = 0)
+      assertEquals(0, config.loraId)
+    }
+
+    test("sessionConfig_positiveLoraIdIsValid") {
+      val config = SessionConfig(loraId = 42)
+      assertEquals(42, config.loraId)
+    }
+
+    test("sessionConfig_negativeLoraIdThrows") {
+      assertThrows<IllegalArgumentException> {
+        SessionConfig(loraId = -1)
+      }
+    }
+
+    test("sessionConfig_withSamplerConfigAndLoraId") {
+      val samplerConfig = SamplerConfig(topK = 40, topP = 0.95, temperature = 0.7)
+      val config = SessionConfig(samplerConfig = samplerConfig, loraId = 5)
+      assertEquals(samplerConfig, config.samplerConfig)
+      assertEquals(5, config.loraId)
+    }
+
+    test("conversationConfig_defaultLoraIdIsNull") {
+      val config = ConversationConfig()
+      assertNull(config.loraId)
+    }
+
+    test("conversationConfig_loraIdZeroIsValid") {
+      val config = ConversationConfig(loraId = 0)
+      assertEquals(0, config.loraId)
+    }
+
+    test("conversationConfig_positiveLoraIdIsValid") {
+      val config = ConversationConfig(loraId = 99)
+      assertEquals(99, config.loraId)
+    }
+
+    test("conversationConfig_negativeLoraIdThrows") {
+      assertThrows<IllegalArgumentException> {
+        ConversationConfig(loraId = -1)
+      }
+    }
+
+    test("conversationConfig_withSamplerConfigAndLoraId") {
+      val samplerConfig = SamplerConfig(topK = 10, topP = 0.5, temperature = 0.1)
+      val config = ConversationConfig(samplerConfig = samplerConfig, loraId = 3)
+      assertEquals(samplerConfig, config.samplerConfig)
+      assertEquals(3, config.loraId)
+    }
+
+    test("sessionConfig_copyWithDifferentLoraId") {
+      val original = SessionConfig(loraId = 1)
+      val copied = original.copy(loraId = 2)
+      assertEquals(1, original.loraId)
+      assertEquals(2, copied.loraId)
+    }
+
+    test("conversationConfig_copyWithDifferentLoraId") {
+      val original = ConversationConfig(loraId = 10)
+      val copied = original.copy(loraId = 20)
+      assertEquals(10, original.loraId)
+      assertEquals(20, copied.loraId)
+    }
+
+    println()
+    println("Results: $testsPassed passed, $testsFailed failed")
+
+    if (testsFailed > 0) {
+      System.exit(1)
+    }
+  }
+}

--- a/kotlin/java/com/google/ai/edge/litertlm/LiteRtLmJni.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/LiteRtLmJni.kt
@@ -70,6 +70,20 @@ internal object LiteRtLmJni {
   external fun nativeCreateSession(enginePointer: Long, samplerConfig: SamplerConfig?): Long
 
   /**
+   * Creates a new LiteRT-LM session with a specific LoRA adapter.
+   *
+   * @param enginePointer A pointer to the native engine instance.
+   * @param samplerConfig The sampler configuration.
+   * @param loraId The LoRA adapter ID to use, or -1 for base model.
+   * @return A pointer to the native session instance.
+   */
+  external fun nativeCreateSessionWithLora(
+    enginePointer: Long,
+    samplerConfig: SamplerConfig?,
+    loraId: Int
+  ): Long
+
+  /**
    * Delete the LiteRT-LM session.
    *
    * @param sessionPointer A pointer to the native session instance.
@@ -168,6 +182,27 @@ internal object LiteRtLmJni {
     messageJsonString: String,
     toolsDescriptionJsonString: String,
     enableConversationConstrainedDecoding: Boolean,
+  ): Long
+
+  /**
+   * Creates a new LiteRT-LM conversation with a specific LoRA adapter.
+   *
+   * @param enginePointer A pointer to the native engine instance.
+   * @param samplerConfig The sampler configuration.
+   * @param messageJsonString The system instruction to be used in the conversation.
+   * @param toolsDescriptionJsonString A json string of a list of tool definitions (Open API json).
+   * @param enableConversationConstrainedDecoding Whether to enable conversation constrained
+   *   decoding.
+   * @param loraId The LoRA adapter ID to use, or -1 for base model.
+   * @return A pointer to the native conversation instance.
+   */
+  external fun nativeCreateConversationWithLora(
+    enginePointer: Long,
+    samplerConfig: SamplerConfig?,
+    messageJsonString: String,
+    toolsDescriptionJsonString: String,
+    enableConversationConstrainedDecoding: Boolean,
+    loraId: Int,
   ): Long
 
   /**


### PR DESCRIPTION
session-aware LoRA

  - Per-session LoRA adapter switching in ExecutionManager
  - LoRA buffers wired into executor forward pass
  - Warning logged when LoRA buffer retrieval fails
  - Full API exposure: C API, JNI bindings, and Kotlin layer with
  validation

  MeZO

  - Core MeZO fine-tuning support with C API (litert_lm_mezo_*
  functions)
  - Unit tests for MeZO fine-tuner
  - Three-session MeZO + LoRA isolation test (validates independent
  adapter state)
  
  
  todo:  backprop a la apple/ml-mebp)