### PR TITLE
ExecutionManager: keep original callback on early StartTask failures

### DIFF
--- a/runtime/framework/resource_management/execution_manager.h
+++ b/runtime/framework/resource_management/execution_manager.h
@@ -320,6 +320,11 @@ class ExecutionManager {
       absl::AnyInvocable<void(absl::StatusOr<Responses>)> absl_nonnull callback)
       ABSL_LOCKS_EXCLUDED(session_and_task_lookup_mutex_);
 
+  // Moves task callback out of task lookup for terminal propagation in early
+  // start failures.
+  absl::AnyInvocable<void(absl::StatusOr<Responses>)> TakeTaskCallback(
+      TaskId task_id) ABSL_LOCKS_EXCLUDED(session_and_task_lookup_mutex_);
+
   // Returns all following tasks that are waiting.
   // - task_id: The task ID of the task.
   // Returns:


### PR DESCRIPTION
### Problem

If `StartTask` fails early, caller callback can be lost in `Add*Task` paths.

### Change

I keep and use the original callback when early start fails.

Touched paths:
1. `AddPrefillTask`
2. `AddDecodeTask`
3. `AddCloneSessionTask`
4. `AddTextScoringTask`

### Files

1. `runtime/framework/resource_management/execution_manager.cc`
2. `runtime/framework/resource_management/execution_manager.h`

### Removed/added code rationale

1. Added: `TakeTaskCallback(task_id)` to move original callback from task map.
2. Replaced no-op callback in early failure branch with original callback.
3. No success-path behavior change.

Related to #1226 and #966 and #1243
Part of PR chain for session-clone stabilization: #1508 #1510 #1511 #1512 #1513 #1514 #1515 #1516.
