### PR TITLE
SessionAdvanced: clear stale dependency roots after terminal fail/cancel

### DIFF
--- a/runtime/core/session_advanced.cc
+++ b/runtime/core/session_advanced.cc
@@ -32,6 +32,7 @@
 #include "absl/status/statusor.h"  // from @com_google_absl
 #include "absl/strings/str_cat.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/synchronization/notification.h"  // from @com_google_absl
 #include "runtime/components/tokenizer.h"
 #include "runtime/core/session_utils.h"
 #include "runtime/engine/engine.h"
@@ -45,6 +46,27 @@ namespace litert::lm {
 namespace {
 
 using TaskController = Engine::Session::TaskController;
+
+absl::Status BuildStructuredCancelledStatus(absl::string_view reason_code,
+                                            absl::string_view origin_component,
+                                            SessionId session_id,
+                                            bool is_prefill, bool is_decode) {
+  return absl::CancelledError(absl::StrCat(
+      "cancel_reason_code=", reason_code, ";origin_component=",
+      origin_component, ";generation_id=0;session_id=", session_id,
+      ";is_prefill=", is_prefill ? "1" : "0", ";is_decode=",
+      is_decode ? "1" : "0", ";op_id=0"));
+}
+
+void ClearLastTaskIdsWithReason(SessionId session_id,
+                                absl::flat_hash_set<TaskId>& last_task_ids,
+                                absl::string_view reason) {
+  ABSL_LOG(WARNING) << "session_last_task_ids_cleared"
+                    << " session_id=" << session_id
+                    << " reason=" << reason
+                    << " prev_count=" << last_task_ids.size();
+  last_task_ids.clear();
+}
 
 }  // namespace
 
@@ -69,11 +91,41 @@ absl::StatusOr<std::unique_ptr<SessionAdvanced>> SessionAdvanced::Create(
 
 absl::Status SessionAdvanced::RunPrefill(
     const std::vector<InputData>& contents) {
+  ABSL_LOG(INFO) << "session_run_prefill_start session_id=" << session_id_
+                 << " session_state=" << static_cast<int>(session_state_)
+                 << " input_count=" << contents.size();
   absl::Status status = absl::OkStatus();
   ASSIGN_OR_RETURN(
       auto task_controller,
-      RunPrefillAsync(contents, [&status](absl::StatusOr<Responses> responses) {
-        status = responses.status();
+      RunPrefillAsync(contents,
+                      [this, &status](absl::StatusOr<Responses> responses) {
+        if (!responses.ok()) {
+          ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                     "prefill_sync_callback_error_status");
+          status = responses.status();
+          return;
+        }
+        if (responses->GetTaskState() == TaskState::kCancelled ||
+            responses->GetTaskState() == TaskState::kDependentTaskCancelled) {
+          ABSL_LOG(WARNING)
+              << "session_run_prefill_cancelled session_id=" << session_id_
+              << " task_state=" << responses->GetTaskState();
+          ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                     "prefill_sync_callback_cancelled_state");
+          status = BuildStructuredCancelledStatus(
+              "PREFILL_TASK_CANCELLED_STATE", "SCHEDULER", session_id_,
+              /*is_prefill=*/true, /*is_decode=*/false);
+          return;
+        }
+        if (responses->GetTaskState() == TaskState::kFailed ||
+            responses->GetTaskState() == TaskState::kDependentTaskFailed) {
+          ABSL_LOG(WARNING) << "session_run_prefill_failed session_id="
+                            << session_id_
+                            << " task_state=" << responses->GetTaskState();
+          ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                     "prefill_sync_callback_failed_state");
+        }
+        status = absl::OkStatus();
       }));
   RETURN_IF_ERROR(task_controller->WaitUntilDone(Engine::kDefaultTimeout));
   return status;
@@ -118,6 +170,9 @@ SessionAdvanced::RunPrefillAsync(
                            *tokenizer_, session_info_->benchmark_info));
   }
   ASSIGN_OR_RETURN(auto task_id, execution_manager_lock->GetNewTaskId());
+  ABSL_LOG(INFO) << "session_prefill_task_created session_id=" << session_id_
+                 << " task_id=" << task_id
+                 << " dep_count=" << last_task_ids_.size();
   RETURN_IF_ERROR(execution_manager_lock->AddPrefillTask(
       session_id_, task_id, std::move(preprocessed_contents), last_task_ids_,
       cancelled, std::move(callback)));
@@ -148,11 +203,35 @@ absl::StatusOr<Responses> SessionAdvanced::RunDecode(
                 std::vector<float>(
                     session_info_->session_config.GetNumOutputCandidates()));
   int num_decode_tokens = 0;
-  auto decode_sync_callback = [&collected_responses, &num_decode_tokens](
+  auto decode_sync_callback = [this, &collected_responses, &num_decode_tokens](
                                   absl::StatusOr<Responses> responses) {
     if (!responses.ok()) {
+      ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                 "decode_sync_callback_error_status");
       collected_responses = responses.status();
       return;
+    }
+    if (responses->GetTaskState() == TaskState::kCancelled ||
+        responses->GetTaskState() == TaskState::kDependentTaskCancelled) {
+      ABSL_LOG(WARNING)
+          << "session_run_decode_cancelled session_id=" << session_id_
+          << " task_state=" << responses->GetTaskState();
+      ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                 "decode_sync_callback_cancelled_state");
+      collected_responses =
+          BuildStructuredCancelledStatus("DECODE_TASK_CANCELLED_STATE",
+                                         "SCHEDULER", session_id_,
+                                         /*is_prefill=*/false,
+                                         /*is_decode=*/true);
+      return;
+    }
+    if (responses->GetTaskState() == TaskState::kFailed ||
+        responses->GetTaskState() == TaskState::kDependentTaskFailed) {
+      ABSL_LOG(WARNING) << "session_run_decode_failed session_id="
+                        << session_id_
+                        << " task_state=" << responses->GetTaskState();
+      ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                 "decode_sync_callback_failed_state");
     }
     collected_responses->SetTaskState(responses->GetTaskState());
     // If the task is not completed and there is no text or score, we can
@@ -234,6 +313,9 @@ absl::StatusOr<std::unique_ptr<TaskController>> SessionAdvanced::RunDecodeAsync(
                              *tokenizer_, session_info_->benchmark_info));
       auto noop_callback = [](absl::StatusOr<Responses> responses) {};
       ASSIGN_OR_RETURN(auto task_id, execution_manager_lock->GetNewTaskId());
+      ABSL_LOG(INFO) << "session_prefill_tail_task_created session_id="
+                     << session_id_ << " task_id=" << task_id
+                     << " dep_count=" << last_task_ids_.size();
       RETURN_IF_ERROR(execution_manager_lock->AddPrefillTask(
           session_id_, task_id, std::move(preprocessed_contents),
           last_task_ids_, cancelled, std::move(noop_callback)));
@@ -243,10 +325,31 @@ absl::StatusOr<std::unique_ptr<TaskController>> SessionAdvanced::RunDecodeAsync(
   session_state_ = SessionState::kDecoded;
 
   ASSIGN_OR_RETURN(auto task_id, execution_manager_lock->GetNewTaskId());
+  ABSL_LOG(INFO) << "session_decode_task_created session_id=" << session_id_
+                 << " task_id=" << task_id
+                 << " dep_count=" << last_task_ids_.size();
+
+  auto wrapped_callback =
+      [this, callback = std::move(callback)](
+          absl::StatusOr<Responses> responses) mutable {
+        if (!responses.ok()) {
+          ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                     "decode_async_callback_error_status");
+        } else if (responses->GetTaskState() == TaskState::kCancelled ||
+                   responses->GetTaskState() ==
+                       TaskState::kDependentTaskCancelled ||
+                   responses->GetTaskState() == TaskState::kFailed ||
+                   responses->GetTaskState() ==
+                       TaskState::kDependentTaskFailed) {
+          ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                     "decode_async_callback_terminal_state");
+        }
+        callback(std::move(responses));
+      };
 
   RETURN_IF_ERROR(execution_manager_lock->AddDecodeTask(
       session_id_, task_id, last_task_ids_, decode_config.GetConstraint(),
-      cancelled, std::move(callback),
+      cancelled, std::move(wrapped_callback),
       decode_config.GetMaxOutputTokens().value_or(
           session_info_->session_config.GetMaxOutputTokens())));
 
@@ -326,6 +429,8 @@ absl::Status SessionAdvanced::GenerateContentStream(
       [this, decode_config, stream_callback = std::move(callback)](
           absl::StatusOr<Responses> prefill_responses) mutable {
         if (!prefill_responses.ok()) {
+          ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                     "stream_prefill_callback_error_status");
           stream_callback(prefill_responses.status());
           return;
         }
@@ -337,8 +442,15 @@ absl::Status SessionAdvanced::GenerateContentStream(
                             << decode_task_controller.status();
           }
         } else if (IsTaskEndState(prefill_responses->GetTaskState())) {
-          stream_callback(absl::CancelledError(
-              "Prefill task finished in cancelled state."));
+          ABSL_LOG(WARNING)
+              << "session_stream_prefill_end_non_done session_id="
+              << session_id_
+              << " prefill_state=" << prefill_responses->GetTaskState();
+          ClearLastTaskIdsWithReason(session_id_, last_task_ids_,
+                                     "stream_prefill_callback_end_non_done");
+          stream_callback(BuildStructuredCancelledStatus(
+              "PREFILL_TASK_CANCELLED_STATE", "SCHEDULER", session_id_,
+              /*is_prefill=*/true, /*is_decode=*/false));
         }
       };
 
@@ -366,13 +478,20 @@ absl::StatusOr<BenchmarkInfo*> SessionAdvanced::GetMutableBenchmarkInfo() {
 }
 
 absl::StatusOr<std::unique_ptr<Engine::Session>> SessionAdvanced::Clone() {
-  absl::Status status = absl::OkStatus();
+  auto status = std::make_shared<absl::Status>(absl::OkStatus());
+  auto callback_done = std::make_shared<absl::Notification>();
   ASSIGN_OR_RETURN(auto session,
-                   CloneAsync([&status](absl::StatusOr<Responses> responses) {
-                     status = responses.status();
+                   CloneAsync([status, callback_done](
+                                  absl::StatusOr<Responses> responses) {
+                     *status = responses.status();
+                     callback_done->Notify();
                    }));
   RETURN_IF_ERROR(WaitUntilDone());
-  RETURN_IF_ERROR(status);
+  if (!callback_done->WaitForNotificationWithTimeout(Engine::kDefaultTimeout)) {
+    return absl::DeadlineExceededError(
+        "Timed out waiting for clone callback completion.");
+  }
+  RETURN_IF_ERROR(*status);
   return session;
 }
 


### PR DESCRIPTION
### Problem

After terminal fail/cancel, `last_task_ids_` can keep stale roots and affect later independent work.

### Change

I clear `last_task_ids_` in terminal fail/cancel paths in `SessionAdvanced`.

### File

1. `runtime/core/session_advanced.cc`

### removed/added code reason

1. Added explicit cleanup where terminal states are handled.
2. Keeps normal success path unchanged.
3. Prevents stale dependency roots from leaking into next turn.

### Related

Related to #1226 and #966 and #1243
Part of PR chain for session-clone stabilization: #1508 #1510 #1511 #1512 #1513 #1514 #1515 #1516.