### PR TITLE
runtime: add executor context clone/restore runtime state APIs

### DIFF
--- a/runtime/executor/llm_executor_base.h
+++ b/runtime/executor/llm_executor_base.h
@@ -21,6 +21,7 @@
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/cc/litert_tensor_buffer.h"  // from @litert
 #include "runtime/executor/llm_executor_io_types.h"
+#include "runtime/executor/llm_executor_processed_tokens.h"
 #include "runtime/executor/llm_executor_settings.h"
 
 namespace litert::lm {
@@ -106,6 +107,63 @@ class LlmExecutorBase {
         absl::StrCat("SetCurrentStep not implemented for backend: ",
                      ExecutorBackendName()));
   };
+
+  // Clones the current context from executor.
+  virtual absl::StatusOr<std::unique_ptr<LlmContext>> CloneContext() const {
+    return absl::UnimplementedError(absl::StrCat(
+        "CloneContext not implemented for backend: ", ExecutorBackendName()));
+  }
+
+  // Restores context into executor.
+  virtual absl::Status RestoreContext(std::unique_ptr<LlmContext> llm_context) {
+    return absl::UnimplementedError(absl::StrCat(
+        "RestoreContext not implemented for backend: ", ExecutorBackendName()));
+  }
+
+  virtual absl::Status UpdateRuntimeConfig(
+      const RuntimeConfig& runtime_config) {
+    return absl::UnimplementedError(
+        absl::StrCat("UpdateRuntimeConfig not implemented for backend: ",
+                     ExecutorBackendName()));
+  }
+
+  virtual absl::StatusOr<RuntimeConfig> GetRuntimeConfig() const {
+    return absl::UnimplementedError(
+        absl::StrCat("GetRuntimeConfig not implemented for backend: ",
+                     ExecutorBackendName()));
+  }
+
+  virtual absl::Status UpdateRuntimeState(const RuntimeState& runtime_state) {
+    return absl::UnimplementedError(
+        absl::StrCat("UpdateRuntimeState not implemented for backend: ",
+                     ExecutorBackendName()));
+  }
+
+  virtual absl::StatusOr<RuntimeState> GetRuntimeState() const {
+    return absl::UnimplementedError(
+        absl::StrCat("GetRuntimeState not implemented for backend: ",
+                     ExecutorBackendName()));
+  }
+
+  virtual absl::StatusOr<std::unique_ptr<LlmContext>> CreateNewContext(
+      std::optional<uint32_t> lora_id, RuntimeConfig runtime_config) {
+    return absl::UnimplementedError(
+        absl::StrCat("CreateNewContext not implemented for backend: ",
+                     ExecutorBackendName()));
+  }
+
+  virtual absl::StatusOr<const ProcessedTokens*> GetProcessedTokens() const {
+    return absl::UnimplementedError(
+        absl::StrCat("GetProcessedTokens not implemented for backend: ",
+                     ExecutorBackendName()));
+  }
+
+  virtual absl::Status LoadLoRA(uint32_t lora_id,
+                                const ModelAssets& model_assets) {
+    return absl::UnimplementedError(
+        absl::StrCat("LoadLoRA not implemented for backend: ",
+                     ExecutorBackendName()));
+  }
 
   // Gets the executor settings of the executor.
   virtual absl::StatusOr<LlmExecutorSettings> GetExecutorSettings() const {

--- a/runtime/executor/llm_processed_context.h
+++ b/runtime/executor/llm_processed_context.h
@@ -46,9 +46,14 @@ class LlmProcessedContext : public ProcessedContext {
     lora_id_ = lora_id;
   }
   ProcessedTokens& processed_tokens() override { return processed_tokens_; }
+  const ProcessedTokens& processed_tokens() const { return processed_tokens_; }
 
   absl::flat_hash_map<absl::string_view, ::litert::TensorBuffer>&
   kv_cache_buffers() {
+    return kv_cache_buffers_;
+  }
+  const absl::flat_hash_map<absl::string_view, ::litert::TensorBuffer>&
+  kv_cache_buffers() const {
     return kv_cache_buffers_;
   }
 

--- a/runtime/framework/resource_management/context_handler/context_handler.h
+++ b/runtime/framework/resource_management/context_handler/context_handler.h
@@ -25,7 +25,6 @@
 #include "absl/status/statusor.h"  // from @com_google_absl
 #include "absl/synchronization/mutex.h"  // from @com_google_absl
 #include "runtime/executor/llm_executor.h"
-#include "runtime/executor/llm_executor_google.h"
 #include "runtime/executor/llm_executor_io_types.h"
 #include "runtime/executor/llm_executor_settings.h"
 #include "runtime/util/status_macros.h"  // NOLINT


### PR DESCRIPTION
Problem
Session clone/reuse paths need explicit context/runtime operations in executor and resource manager layers.

Change
This PR adds runtime context API surface and implementations:
- CloneContext/RestoreContext
- runtime config/state getters and updates
- processed token accessors
- resource manager wiring for context lifecycle

Scope
- runtime/executor/* context API and implementation
- runtime/framework/resource_management/resource_manager.cc
- context_handler header cleanup

Related to #1226 and #966 and #1243
Part of PR chain for session-clone stabilization: #1508 #1510 #1511 #1512 #1513 #1514 #1515 #1516.
