### PR TITLE
kotlin: add engine mode and session clone API surface

### DIFF
--- a/kotlin/java/com/google/ai/edge/litertlm/Config.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/Config.kt
@@ -26,6 +26,25 @@ enum class Backend {
   NPU, // NPU LiteRT backend.
 }
 
+/** Runtime engine mode for LiteRT-LM. */
+enum class EngineMode(val nativeValue: Int) {
+  BASIC(0),
+  ADVANCED(1),
+}
+
+/** Override for GPU activation precision. */
+enum class GpuActivationPrecision {
+  DEFAULT,
+  FP16,
+  FP32,
+}
+
+/** Override for GPU cache behavior. */
+enum class GpuCacheMode {
+  DEFAULT,
+  NOCACHE,
+}
+
 /**
  * Configuration for the LiteRT-LM engine.
  *
@@ -40,6 +59,9 @@ enum class Backend {
  * @property cacheDir The directory for placing cache files. It should be a directory with write
  *   access. If not set, it uses the directory of the [modelPath]. Set to ":nocache" to disable
  *   caching at all.
+ * @property engineMode Runtime engine mode. `BASIC` is default for backward compatibility.
+ * @property gpuActivationPrecision Optional GPU activation precision override.
+ * @property gpuCacheMode Optional GPU cache override.
  */
 data class EngineConfig(
   val modelPath: String,
@@ -48,6 +70,9 @@ data class EngineConfig(
   val audioBackend: Backend? = null,
   val maxNumTokens: Int? = null,
   val cacheDir: String? = null,
+  val engineMode: EngineMode = EngineMode.BASIC,
+  val gpuActivationPrecision: GpuActivationPrecision = GpuActivationPrecision.DEFAULT,
+  val gpuCacheMode: GpuCacheMode = GpuCacheMode.DEFAULT,
 ) {
   init {
     require(maxNumTokens == null || maxNumTokens > 0) {

--- a/kotlin/java/com/google/ai/edge/litertlm/Engine.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/Engine.kt
@@ -74,6 +74,9 @@ class Engine(val engineConfig: EngineConfig) : AutoCloseable {
           engineConfig.cacheDir ?: "",
           @OptIn(ExperimentalApi::class) ExperimentalFlags.enableBenchmark,
           @OptIn(ExperimentalApi::class) ExperimentalFlags.npuLibrariesDir,
+          engineConfig.engineMode.nativeValue,
+          engineConfig.gpuActivationPrecision.name,
+          engineConfig.gpuCacheMode.name,
         )
     }
   }
@@ -148,7 +151,10 @@ class Engine(val engineConfig: EngineConfig) : AutoCloseable {
       checkInitialized()
 
       // Using !! is okay. Checked initialization already.
-      return Session(LiteRtLmJni.nativeCreateSession(handle!!, sessionConfig.samplerConfig))
+      return Session(
+        LiteRtLmJni.nativeCreateSession(handle!!, sessionConfig.samplerConfig),
+        engineConfig.engineMode,
+      )
     }
   }
 

--- a/kotlin/java/com/google/ai/edge/litertlm/LiteRtLmJni.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/LiteRtLmJni.kt
@@ -51,6 +51,9 @@ internal object LiteRtLmJni {
     cacheDir: String,
     enableBenchmark: Boolean,
     npuLibrariesDir: String,
+    engineMode: Int,
+    gpuActivationPrecision: String,
+    gpuCacheMode: String,
   ): Long
 
   /**
@@ -95,13 +98,22 @@ internal object LiteRtLmJni {
   external fun nativeDeleteSession(sessionPointer: Long)
 
   /**
+   * Clones an existing LiteRT-LM session.
+   *
+   * @param sessionPointer A pointer to the source native session instance.
+   * @return A pointer to the cloned native session instance.
+   * @throws LiteRtLmJniException if the underlying native method fails.
+   */
+  external fun nativeCloneSession(sessionPointer: Long): Long
+
+  /**
    * Runs the prefill step for the given input data.
    *
    * @param sessionPointer A pointer to the native session instance.
    * @param inputData An array of {@link InputData} to be processed by the model.
    * @throws LiteRtLmJniException if the underlying native method fails.
    */
-  external fun nativeRunPrefill(sessionPointer: Long, inputData: Array<InputData>)
+  external fun nativeRunPrefill(sessionPointer: Long, inputData: Array<InputData>, opId: Long)
 
   /**
    * Runs the decode step.
@@ -110,7 +122,7 @@ internal object LiteRtLmJni {
    * @return The generated content.
    * @throws LiteRtLmJniException if the underlying native method fails.
    */
-  external fun nativeRunDecode(sessionPointer: Long): String
+  external fun nativeRunDecode(sessionPointer: Long, opId: Long): String
 
   /**
    * Generates content from the given input data.
@@ -119,7 +131,11 @@ internal object LiteRtLmJni {
    * @param inputData An array of {@link InputData} to be processed by the model.
    * @return The generated content.
    */
-  external fun nativeGenerateContent(sessionPointer: Long, inputData: Array<InputData>): String
+  external fun nativeGenerateContent(
+    sessionPointer: Long,
+    inputData: Array<InputData>,
+    opId: Long,
+  ): String
 
   /**
    * Generates content from the given input data in a streaming fashion.
@@ -133,6 +149,7 @@ internal object LiteRtLmJni {
   external fun nativeGenerateContentStream(
     sessionPointer: Long,
     inputData: Array<InputData>,
+    opId: Long,
     callback: JniInferenceCallback,
   )
 

--- a/kotlin/java/com/google/ai/edge/litertlm/Session.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/Session.kt
@@ -17,14 +17,20 @@ package com.google.ai.edge.litertlm
 
 import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Manages the lifecycle of a LiteRT-LM session, providing an interface for interacting with the
  * native library.
  *
  * @param handle The pointer to the underlying native session object.
+ * @param engineMode The mode of the owning engine.
  */
-class Session(private val handle: Long) : AutoCloseable {
+class Session(private val handle: Long, private val engineMode: EngineMode) : AutoCloseable {
+  private companion object {
+    private val nextOpId = AtomicLong(1L)
+  }
+
   private val _isAlive = AtomicBoolean(true)
 
   /** Whether the session is alive and ready to be used, */
@@ -57,7 +63,8 @@ class Session(private val handle: Long) : AutoCloseable {
    */
   fun runPrefill(inputData: List<InputData>) {
     checkIsAlive()
-    return LiteRtLmJni.nativeRunPrefill(handle, inputData.toTypedArray())
+    val opId = nextOpId.getAndIncrement()
+    return LiteRtLmJni.nativeRunPrefill(handle, inputData.toTypedArray(), opId)
   }
 
   /**
@@ -71,7 +78,8 @@ class Session(private val handle: Long) : AutoCloseable {
    */
   fun runDecode(): String {
     checkIsAlive()
-    return LiteRtLmJni.nativeRunDecode(handle)
+    val opId = nextOpId.getAndIncrement()
+    return LiteRtLmJni.nativeRunDecode(handle, opId)
   }
 
   /**
@@ -87,7 +95,8 @@ class Session(private val handle: Long) : AutoCloseable {
    */
   fun generateContent(inputData: List<InputData>): String {
     checkIsAlive()
-    return LiteRtLmJni.nativeGenerateContent(handle, inputData.toTypedArray())
+    val opId = nextOpId.getAndIncrement()
+    return LiteRtLmJni.nativeGenerateContent(handle, inputData.toTypedArray(), opId)
   }
 
   /**
@@ -101,8 +110,9 @@ class Session(private val handle: Long) : AutoCloseable {
    */
   fun generateContentStream(inputData: List<InputData>, responseCallback: ResponseCallback) {
     checkIsAlive()
+    val opId = nextOpId.getAndIncrement()
     val jniCallback = JniInferenceCallbackImpl(responseCallback)
-    LiteRtLmJni.nativeGenerateContentStream(handle, inputData.toTypedArray(), jniCallback)
+    LiteRtLmJni.nativeGenerateContentStream(handle, inputData.toTypedArray(), opId, jniCallback)
   }
 
   private inner class JniInferenceCallbackImpl(private val callback: ResponseCallback) :
@@ -134,6 +144,21 @@ class Session(private val handle: Long) : AutoCloseable {
   fun cancelProcess() {
     checkIsAlive()
     LiteRtLmJni.nativeCancelProcess(handle)
+  }
+
+  /**
+   * Creates a clone of this session at its current state.
+   *
+   * @return A new [Session] with copied model state.
+   * @throws IllegalStateException if the session is not alive.
+   * @throws LiteRtLmJniException if cloning fails in native code.
+   */
+  fun clone(): Session {
+    checkIsAlive()
+    if (engineMode != EngineMode.ADVANCED) {
+      throw LiteRtLmJniException("Session.clone() requires EngineMode.ADVANCED")
+    }
+    return Session(LiteRtLmJni.nativeCloneSession(handle), engineMode)
   }
 
   /** Throws [IllegalStateException] if the session is not alive. */


### PR DESCRIPTION
Problem
Kotlin API currently lacks explicit advanced engine mode and session clone surface needed for the Android clone workflow.

Change
This PR adds Kotlin-side API surface:
- engine mode and GPU override enums in config
- engine/session wiring for advanced mode
- JNI signatures for clone and op_id-aware calls
- Session.clone() and op_id propagation

Scope
- kotlin/java/com/google/ai/edge/litertlm/Config.kt
- kotlin/java/com/google/ai/edge/litertlm/Engine.kt
- kotlin/java/com/google/ai/edge/litertlm/LiteRtLmJni.kt
- kotlin/java/com/google/ai/edge/litertlm/Session.kt


Related to #1226 and #966 and #1243
Part of PR chain for session-clone stabilization: #1508 #1510 #1511 #1512 #1513 #1514 #1515 #1516.