### PR TITLE
[LiteRT-LM][PR-8] Android no-LLG guards in constrained decoding and processors

### DIFF
--- a/runtime/components/constrained_decoding/BUILD
+++ b/runtime/components/constrained_decoding/BUILD
@@ -320,7 +320,10 @@ cc_test(
 
 cc_library(
     name = "constraint_provider_factory",
-    srcs = ["constraint_provider_factory.cc"],
+    srcs = select({
+        "@platforms//os:android": ["constraint_provider_factory_no_llg.cc"],
+        "//conditions:default": ["constraint_provider_factory.cc"],
+    }),
     hdrs = ["constraint_provider_factory.h"],
     deps = [
         ":constraint_provider",
@@ -328,11 +331,13 @@ cc_library(
         ":external_constraint_config",
         ":external_constraint_provider",
         ":llg_constraint_config",
-        ":llg_constraint_provider",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "//runtime/components:tokenizer",
-    ],
+    ] + select({
+        "@platforms//os:android": [],
+        "//conditions:default": [":llg_constraint_provider"],
+    }),
 )
 
 cc_test(

--- a/runtime/components/constrained_decoding/constraint_provider_factory_no_llg.cc
+++ b/runtime/components/constrained_decoding/constraint_provider_factory_no_llg.cc
@@ -1,0 +1,34 @@
+#include "runtime/components/constrained_decoding/constraint_provider_factory.h"
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "runtime/components/constrained_decoding/constraint_provider.h"
+#include "runtime/components/constrained_decoding/constraint_provider_config.h"
+#include "runtime/components/constrained_decoding/external_constraint_config.h"
+#include "runtime/components/constrained_decoding/external_constraint_provider.h"
+#include "runtime/components/constrained_decoding/llg_constraint_config.h"
+#include "runtime/components/tokenizer.h"
+
+namespace litert::lm {
+
+absl::StatusOr<std::unique_ptr<ConstraintProvider>> CreateConstraintProvider(
+    const ConstraintProviderConfig& constraint_provider_config,
+    const Tokenizer& tokenizer,
+    const std::vector<std::vector<int>>& stop_token_ids) {
+  if (std::holds_alternative<ExternalConstraintConfig>(
+          constraint_provider_config)) {
+    return std::make_unique<ExternalConstraintProvider>();
+  } else if (std::holds_alternative<LlGuidanceConfig>(
+                 constraint_provider_config)) {
+    return absl::UnimplementedError(
+        "LlGuidance constraint provider is disabled in this Android build.");
+  }
+
+  return absl::UnimplementedError("Unknown ConstraintProviderConfig type.");
+}
+
+}  // namespace litert::lm

--- a/runtime/conversation/model_data_processor/BUILD
+++ b/runtime/conversation/model_data_processor/BUILD
@@ -203,11 +203,15 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
         "@nlohmann_json//:json",
-        "//runtime/components/tool_use:parser_utils",
         "//runtime/conversation:io_types",
         "//runtime/engine:io_types",
         "//runtime/util:litert_status_util",
-    ],
+    ] + select({
+        "@platforms//os:android": [],
+        "//conditions:default": [
+            "//runtime/components/tool_use:parser_utils",
+        ],
+    }),
 )
 
 cc_test(
@@ -248,8 +252,6 @@ cc_library(
         "//runtime/components/preprocessor:audio_preprocessor_miniaudio",
         "//runtime/components/preprocessor:image_preprocessor",
         "//runtime/components/preprocessor:stb_image_preprocessor",
-        "//runtime/components/tool_use:parser_utils",
-        "//runtime/components/tool_use:python_tool_format_utils",
         "//runtime/conversation:io_types",
         "//runtime/conversation:prompt_utils",
         "//runtime/engine:io_types",
@@ -257,7 +259,13 @@ cc_library(
         "//runtime/util:memory_mapped_file",
         "@com_googlesource_code_re2//:re2",
         "@sentencepiece//:sentencepiece_model_cc_proto",
-    ],
+    ] + select({
+        "@platforms//os:android": [],
+        "//conditions:default": [
+            "//runtime/components/tool_use:parser_utils",
+            "//runtime/components/tool_use:python_tool_format_utils",
+        ],
+    }),
 )
 
 cc_test(
@@ -308,13 +316,17 @@ cc_library(
         "//runtime/components:tokenizer",
         "//runtime/components/constrained_decoding:constraint",
         "//runtime/components/constrained_decoding:gemma_model_constraint_provider_lib",
-        "//runtime/components/tool_use:fc_tool_format_utils",
-        "//runtime/components/tool_use:parser_utils",
         "//runtime/conversation:io_types",
         "//runtime/engine:io_types",
         "//runtime/util:litert_status_util",
         "@sentencepiece//:sentencepiece_model_cc_proto",
-    ],
+    ] + select({
+        "@platforms//os:android": [],
+        "//conditions:default": [
+            "//runtime/components/tool_use:fc_tool_format_utils",
+            "//runtime/components/tool_use:parser_utils",
+        ],
+    }),
 )
 
 cc_test(

--- a/runtime/conversation/model_data_processor/gemma3_data_processor.cc
+++ b/runtime/conversation/model_data_processor/gemma3_data_processor.cc
@@ -32,9 +32,7 @@
 #include "nlohmann/json_fwd.hpp"  // from @nlohmann_json
 #include "litert/cc/litert_layout.h"  // from @litert
 #include "runtime/components/constrained_decoding/constraint.h"
-#if !defined(LITERT_LM_GEMMA_CONSTRAINT_DISABLED)
 #include "runtime/components/constrained_decoding/gemma_model_constraint_provider.h"
-#endif
 #include "runtime/components/preprocessor/audio_preprocessor.h"
 #include "runtime/components/preprocessor/audio_preprocessor_miniaudio.h"
 #include "runtime/components/preprocessor/image_preprocessor.h"
@@ -42,8 +40,10 @@
 #include "runtime/components/prompt_template.h"
 #include "runtime/components/sentencepiece_tokenizer.h"
 #include "runtime/components/tokenizer.h"
+#if !defined(__ANDROID__)
 #include "runtime/components/tool_use/parser_utils.h"
 #include "runtime/components/tool_use/python_tool_format_utils.h"
+#endif
 #include "runtime/conversation/io_types.h"
 #include "runtime/conversation/model_data_processor/data_utils.h"
 #include "runtime/conversation/model_data_processor/gemma3_data_processor_config.h"
@@ -102,6 +102,10 @@ bool IsToolMessage(const ordered_json& message) {
 
 absl::StatusOr<std::string> FormatToolResponse(
     const ordered_json& tool_response) {
+#if defined(__ANDROID__)
+  return absl::UnimplementedError(
+      "Tool response formatting is unavailable in Android local build.");
+#else
   absl::string_view tool_response_key;
   if (tool_response.contains("tool_response")) {
     tool_response_key = "tool_response";
@@ -112,6 +116,7 @@ absl::StatusOr<std::string> FormatToolResponse(
   }
 
   return FormatValueAsPython(tool_response[tool_response_key]);
+#endif
 }
 
 }  // namespace
@@ -122,18 +127,6 @@ Gemma3DataProcessor::Create(Gemma3DataProcessorConfig config,
                             const Tokenizer* tokenizer,
                             const std::vector<std::vector<int>>& stop_token_ids,
                             bool enable_constrained_decoding) {
-#if defined(LITERT_LM_GEMMA_CONSTRAINT_DISABLED)
-  if (enable_constrained_decoding) {
-    return absl::FailedPreconditionError(
-        "Constrained decoding was disabled at build time.");
-  }
-  ASSIGN_OR_RETURN(auto audio_preprocessor,
-                   AudioPreprocessorMiniAudio::Create(
-                       AudioPreprocessorConfig::CreateDefaultUsmConfig()));
-  return absl::WrapUnique(new Gemma3DataProcessor(
-      config, preface, std::make_unique<StbImagePreprocessor>(),
-      std::move(audio_preprocessor)));
-#else
   std::unique_ptr<LiteRtLmGemmaModelConstraintProvider,
                   decltype(&LiteRtLmGemmaModelConstraintProvider_Destroy)>
       constraint_provider(nullptr,
@@ -173,7 +166,6 @@ Gemma3DataProcessor::Create(Gemma3DataProcessorConfig config,
   return absl::WrapUnique(new Gemma3DataProcessor(
       std::move(constraint_provider), config, preface,
       std::make_unique<StbImagePreprocessor>(), std::move(audio_preprocessor)));
-#endif
 }
 
 absl::StatusOr<ordered_json> Gemma3DataProcessor::MessageToTemplateInput(
@@ -234,9 +226,13 @@ absl::StatusOr<ordered_json> Gemma3DataProcessor::MessageToTemplateInput(
       if (function.contains("arguments")) {
         if (function["arguments"].is_object()) {
           for (const auto& [key, value] : function["arguments"].items()) {
+#if defined(__ANDROID__)
+            tool_call_input["function"]["arguments"][key] = value;
+#else
             ASSIGN_OR_RETURN(std::string formatted_value,
                              FormatValueAsPython(value));
             tool_call_input["function"]["arguments"][key] = formatted_value;
+#endif
           }
         } else {
           tool_call_input["function"]["arguments"] = function["arguments"];
@@ -428,6 +424,11 @@ absl::StatusOr<Message> Gemma3DataProcessor::ToMessageImpl(
     const Gemma3DataProcessorArguments& args) const {
   absl::string_view response_text = responses.GetTexts()[0];
   ordered_json message = {{"role", "assistant"}};
+#if defined(__ANDROID__)
+  message["content"] = ordered_json::array(
+      {{{"type", "text"}, {"text", std::string(response_text)}}});
+  return message;
+#else
   if (preface_.has_value() && std::holds_alternative<JsonPreface>(*preface_) &&
       !std::get<JsonPreface>(*preface_).tools.empty()) {
     ASSIGN_OR_RETURN(
@@ -447,10 +448,14 @@ absl::StatusOr<Message> Gemma3DataProcessor::ToMessageImpl(
         {{{"type", "text"}, {"text", std::string(response_text)}}});
   }
   return message;
+#endif
 }
 
 absl::StatusOr<ordered_json> Gemma3DataProcessor::FormatTools(
     const ordered_json& tools) const {
+#if defined(__ANDROID__)
+  return tools;
+#else
   if (!tools.is_array()) {
     return absl::InvalidArgumentError("Tools must be an array.");
   }
@@ -460,16 +465,12 @@ absl::StatusOr<ordered_json> Gemma3DataProcessor::FormatTools(
     formatted_tools.push_back(formatted_tool);
   }
   return formatted_tools;
+#endif
 }
 
 absl::StatusOr<std::unique_ptr<Constraint>>
 Gemma3DataProcessor::CreateConstraint(
     const nlohmann::ordered_json& tools) const {
-#if defined(LITERT_LM_GEMMA_CONSTRAINT_DISABLED)
-  return absl::FailedPreconditionError(
-      "Constrained decoding is disabled at build time, but it was requested "
-      "for inference.");
-#else
   if (constraint_provider_c_ == nullptr) {
     return nullptr;
   }
@@ -499,7 +500,6 @@ Gemma3DataProcessor::CreateConstraint(
     return absl::InternalError("Failed to create constraint with tools.");
   }
   return absl::WrapUnique(reinterpret_cast<Constraint*>(constraint));
-#endif
 }
 
 absl::string_view Gemma3DataProcessor::CodeFenceStart() const {


### PR DESCRIPTION
Problem
Android no-LLG path is not fully wired in constrained decoding and model data processors.
This blocks clean Android integration for the session-clone workflow.

Change
This PR adds Android no-LLG guards and build wiring:

add no-LLG constraint provider factory
wire constrained decoding BUILD target
add Android guards in model data processors (FunctionGemma, Gemma3, Qwen3)
Scope

runtime/components/constrained_decoding/BUILD
[constraint_provider_factory_no_llg.cc](https://file+.vscode-resource.vscode-cdn.net/Users/user/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
runtime/conversation/model_data_processor/BUILD
[function_gemma_data_processor.cc](https://file+.vscode-resource.vscode-cdn.net/Users/user/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[gemma3_data_processor.cc](https://file+.vscode-resource.vscode-cdn.net/Users/user/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[qwen3_data_processor.cc](https://file+.vscode-resource.vscode-cdn.net/Users/user/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)

Related to #1226 and #966 and #1243
Part of PR chain for session-clone stabilization: #1508 #1510 #1511 #1512 #1513 #1514 #1515 #1516.