### PR TITLE
Bump LITERT_REF to include 36ab4fc (fixes iOS Metal GPU crash)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,13 @@
 
 workspace(name = "litert_lm")
 
-# UPDATED = 2026-04-01
-LITERT_REF = "5c42d07c5e457ea535d1a2144a376c95e79a06d5"
+# UPDATED = 2026-04-07 (LiteRT main HEAD; includes commit 36ab4fc which fixes
+# the iOS Metal accelerator dynamic-linking crash by passing Metal device +
+# command queue across the static-lib ↔ dylib boundary via env options instead
+# of transient raw pointers — required for iOS GPU to work at all)
+LITERT_REF = "b5d47c827a4944cc71c31c5e05b5702cf5868d45"
 
-LITERT_SHA256 = "9e7f8f3e9152007a71766332147f6d2deecb3f9178749bc9ed9d76e69178a1c4"
-
+LITERT_SHA256 = "b9e114c93bf053e399201f076e19246adbb09f3343eefb19c211797d9f78f72b"
 TENSORFLOW_REF = "e6f36bd7a12f87aac6f21a5068719dfc91bed3eb"
 
 TENSORFLOW_SHA256 = "643b8e3f23283fb0e6cacc4612e77b285a1d3cfd295aa10b3386fd8fcf6d651f"


### PR DESCRIPTION
## Summary

Bumps `LITERT_REF` in `WORKSPACE` from `5c42d07c…` (Apr 1 2026) to `b5d47c827a4944cc71c31c5e05b5702cf5868d45` (Apr 7 2026, current `@litert` `main` HEAD). This pulls in upstream commit [`36ab4fca1b453f1f746bf024e8874e536b081dbf`](https://github.com/google-ai-edge/LiteRT/commit/36ab4fca1b453f1f746bf024e8874e536b081dbf) (*"Fix metal accelerator crash issue when using dynamic linking"*, ai-edge-bot, Apr 3 2026), which is required for the iOS Metal GPU accelerator to work at all.

## Why

The current pin (`5c42d07c…`, Apr 1) is two days older than the fix. **Anyone building `liblitert_lm_capi.a` from current `LiteRT-LM/main` and trying to load a `.litertlm` model on iOS GPU will hit `EXC_BAD_ACCESS` in `objc_retain` inside `litert::ml_drift::CreateMlDriftMetalDelegate`**, regardless of which prebuilt `libLiteRtMetalAccelerator.dylib` they use.

The crash chain:
```
litert_lm_engine_create
→ EngineFactory::Create
→ CreateLlmLiteRtCompiledModelExecutor
→ LlmLiteRtCompiledModelExecutorStatic::Create
→ CompiledModel::Create
→ LiteRtCreateCompiledModel
→ GpuMetalAccelerator::CreateDelegate
→ litert::ml_drift::CreateDelegate
→ litert::ml_drift::CreateMlDriftMetalDelegate + 828  ← SIGSEGV in objc_retain
```

This is the same crash tracked at [google-ai-edge/LiteRT#6745](https://github.com/google-ai-edge/LiteRT/issues/6745) and is being hit by multiple users on different devices (iPhone 16 Pro Max / A18 Pro, iPhone 17 Pro Max).

### Root cause

Google's prebuilt `libLiteRtMetalAccelerator.dylib` (Apr 6 push of `litert_prebuilts.zip`) was rebuilt from `google3` source containing commit `36ab4fc`. Its `_LiteRtAcceleratorImpl` struct now declares:

```
device_tag = 10  // == kLiteRtEnvOptionTagMetalDevice
queue_tag  = 11  // == kLiteRtEnvOptionTagMetalCommandQueue
```

Meaning the dylib expects to find a Metal device pointer at env option tag 10 and a command queue at tag 11 when its `create_delegate` callback is invoked.

But the Apr 1 `@litert` pin's `litert/runtime/gpu_environment.cc` only **reads** those tags:

```bash
$ grep -nE "AddOption|push_back|kLiteRtEnvOptionTagMetalDevice|kLiteRtEnvOptionTagMetalCommandQueue" \
    external/litert/litert/runtime/gpu_environment.cc
135:      environment_options.GetOption(kLiteRtEnvOptionTagMetalDevice);
137:      environment_options.GetOption(kLiteRtEnvOptionTagMetalCommandQueue);
```

**Two `GetOption` calls. Zero writes.** The static lib never publishes the Metal device + queue, so the dylib reads garbage from those env-option slots, casts the garbage to `id<MTLDevice>`, calls `objc_retain` on it, and crashes.

Commit `36ab4fc` fixes this by adding 14 lines to `gpu_environment.cc` that publish stable Metal handles via env options:

```cpp
// Publish stable Metal handles owned by this GpuEnvironment so later
// delegate creation does not read transient raw pointers from earlier setup.
LITERT_ASSIGN_OR_RETURN(
    auto metal_device, ToLiteRtAny(LiteRtVariant(metal_info_->metal_info)));
generated_options_.push_back(LiteRtEnvOption{
    .tag = kLiteRtEnvOptionTagMetalDevice, .value = metal_device});
LITERT_ASSIGN_OR_RETURN(
    auto metal_command_queue,
    ToLiteRtAny(LiteRtVariant(metal_info_->metal_command_queue)));
generated_options_.push_back(
    LiteRtEnvOption{.tag = kLiteRtEnvOptionTagMetalCommandQueue,
                    .value = metal_command_queue});
```

The comment literally describes the crash. With the new `gpu_environment.cc` compiled into the static lib, the boundary handoff matches what the dylib expects.

## Verification

- Built `//fat:engine_fat` (an `apple_static_library` wrapping `//c:engine`) on macOS + Xcode 26.x + iOS 26.2 SDK with `bazelisk build --config=ios_arm64 --ios_minimum_os=26.2 //fat:engine_fat`. Build completes in ~42s, 271 actions, no patches required.
- Output `bazel-bin/fat/engine_fat_lipo.a` is 230 MB, contains 2,796 object files, target triple `arm64-apple-ios26.2.0` (verified by extracting an `.o` and checking `LC_BUILD_VERSION`).
- The new `gpu_environment.o` is present in the static lib and contains the `Created default Metal device.` log string from line 381 of the new source, immediately above the env-option-publishing code at lines 388–395.
- Linked into a real iOS app with `-force_load`, alongside the Apr 6 `libLiteRtMetalAccelerator.dylib` from `litert_prebuilts.zip`.
- Tested on **iPhone 17 Pro Max running iOS 26.x with `gemma-4-E2B-it.litertlm`** (HuggingFace `litert-community/gemma-4-E2B-it-litert-lm`). `litert_lm_engine_create` with `backend="gpu"` now succeeds; engine pointer is returned cleanly; conversation creation succeeds; the Metal delegate is initialized without a crash.

Before this PR: 100% crash rate on every GPU `engine_create`. After: GPU works.

## SHA256

```
$ curl -sL https://github.com/google-ai-edge/LiteRT/archive/b5d47c827a4944cc71c31c5e05b5702cf5868d45.tar.gz | shasum -a 256
b9e114c93bf053e399201f076e19246adbb09f3343eefb19c211797d9f78f72b
```

## Note on the second half of the fix

Commit `36ab4fc` has two parts: the `gpu_environment.cc` fix (this PR picks up via the pin bump) and a `-fobjc-arc` flag added to `special_rule.bzl` for builds that compile the Metal accelerator dylib from source. The second half is irrelevant to OSS LiteRT-LM consumers because `litert_gpu_accelerator_deps()` returns `[]` in OSS — the dylib is consumed as a prebuilt. That second half is what Google needs to apply when next rebuilding `litert_prebuilts.zip` (tracked separately at [LiteRT#6745](https://github.com/google-ai-edge/LiteRT/issues/6745)). This PR does not depend on that.

## Test plan

- [x] `bazelisk build --config=ios_arm64 --ios_minimum_os=26.2 //fat:engine_fat` succeeds on macOS + Xcode 26 with no local patches
- [x] Resulting `liblitert_lm_capi.a` builds against iOS 26.2 SDK (verified via `otool -l` on extracted object)
- [x] Real-device test on iPhone 17 Pro Max + iOS 26.x: `litert_lm_engine_create(backend="gpu")` succeeds with `gemma-4-E2B-it.litertlm`
- [x] Conversation creation + first inference call succeed
- [ ] CI on this repo passes (only WORKSPACE changes, should be a no-op for non-iOS targets)
