### PR TITLE
Fix heap buffer overflow: add FlatBuffer verification to .litertlm header parser

### DIFF
--- a/schema/core/litertlm_read.cc
+++ b/schema/core/litertlm_read.cc
@@ -36,6 +36,7 @@
 #include "runtime/util/scoped_file.h"
 #include "runtime/util/status_macros.h"  // NOLINT
 #include "schema/core/litertlm_header.h"
+#include "flatbuffers/verifier.h"  // from @flatbuffers
 #include "schema/core/litertlm_header_schema_generated.h"
 #include "schema/core/litertlm_utils.h"
 #include "zconf.h"  // from @zlib
@@ -133,6 +134,15 @@ absl::Status ReadHeaderFromLiteRTLM(std::istream& litertlm_stream,
                        header_size);
   if (!litertlm_stream) {
     return absl::InternalError("Failed to read header data.");
+  }
+
+  // Verify FlatBuffer integrity before interpreting the header.
+  // Without this, a crafted .litertlm file with malicious internal offsets
+  // can cause out-of-bounds heap reads when metadata fields are accessed.
+  flatbuffers::Verifier verifier(header_buffer.get(), header_size);
+  if (!VerifyLiteRTLMMetaDataBuffer(verifier)) {
+    return absl::InvalidArgumentError(
+        "LiteRTLM header contains invalid FlatBuffer metadata.");
   }
 
   header->reset(std::move(header_buffer));


### PR DESCRIPTION
## Summary

- Add FlatBuffer verification via `VerifyLiteRTLMMetaDataBuffer()` before interpreting the header buffer in `ReadHeaderFromLiteRTLM()`
- Without this, a crafted `.litertlm` file with malicious internal FlatBuffer offsets causes out-of-bounds heap reads when metadata fields are accessed
- Aligns header parsing with the existing secure pattern used for LoRA model loading in `lora_data.cc` (`VerifyAndBuildFromBuffer`)

## Problem

`LitertlmHeader::reset()` in `schema/core/litertlm_read.h:93` calls `GetLiteRTLMMetaData()` (which is `flatbuffers::GetRoot<LiteRTLMMetaData>()`) **without calling the FlatBuffers verifier**. The generated verification function `VerifyLiteRTLMMetaDataBuffer()` exists but is never called anywhere in the codebase.

After the unverified parse, callers access `metadata->section_metadata()->objects()` which follows internal FlatBuffer offsets that can point beyond the allocated buffer when processing a crafted file.

### Affected entry points

- `runtime/util/litert_lm_loader.cc:154` — production Android/iOS model loader
- `schema/core/litertlm_print.cc:110` — `litertlm_peek` CLI tool
- `schema/core/litertlm_read.cc:182` — `ReadValueTFromSection` (all section types)
- `schema/core/litertlm_read.cc:466` — `ReadAnyT` (convenience APIs)

## Fix

Added FlatBuffer verification in the core `ReadHeaderFromLiteRTLM(std::istream&, LitertlmHeader*)` function, right after reading the header buffer and before calling `header->reset()`. This protects all downstream callers.

```cpp
flatbuffers::Verifier verifier(header_buffer.get(), header_size);
if (!VerifyLiteRTLMMetaDataBuffer(verifier)) {
    return absl::InvalidArgumentError(
        "LiteRTLM header contains invalid FlatBuffer metadata.");
}
```

## AddressSanitizer Confirmation

Built `//schema/cc:litertlm_peek` with ASAN and tested with a crafted 88-byte `.litertlm` file:

**Before fix:**
```
==93381==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x606000001954
READ of size 4 at 0x606000001954 thread T0
    #0 litert::lm::schema::ProcessLiteRTLMFile()+0x1570

0x606000001954 is located 60 bytes after 56-byte region [0x6060000018e0,0x606000001918)
```

**After fix:**
```
INVALID_ARGUMENT: LiteRTLM header contains invalid FlatBuffer metadata.
```

Legitimate `.litertlm` files (e.g., `runtime/testdata/test_lm_dynamic.litertlm`) continue to parse correctly.

## Test plan

- [x] ASAN build passes
- [x] Malicious `.litertlm` file rejected with clear error (no crash)
- [x] Legitimate test `.litertlm` files still load correctly
- [ ] Existing unit tests pass (`bazel test //schema/core:litertlm_read_test`)