### PR TITLE
memory_mapped_file_posix: map weights as PROT_READ to avoid iOS VM commit

### DIFF
--- a/runtime/util/memory_mapped_file_posix.cc
+++ b/runtime/util/memory_mapped_file_posix.cc
@@ -110,8 +110,17 @@ absl::StatusOr<std::unique_ptr<MemoryMappedFile>> MemoryMappedFile::Create(
     length = file_size - offset;
   }
 
+  // Drop PROT_WRITE so iOS does not eagerly commit the full mapping up
+  // front; weights are read-only anyway. Fall back to PROT_READ|PROT_WRITE
+  // only if the read-only mmap fails (preserves prior behaviour).
   void* data =
-      mmap(nullptr, length, PROT_READ | PROT_WRITE, MAP_PRIVATE, file, offset);
+      mmap(nullptr, length, PROT_READ, MAP_PRIVATE, file, offset);
+  if (data == MAP_FAILED) {
+    ABSL_LOG(WARNING) << "PROT_READ mmap failed (" << strerror(errno)
+                      << "); retrying with PROT_READ|PROT_WRITE.";
+    data = mmap(nullptr, length, PROT_READ | PROT_WRITE, MAP_PRIVATE, file,
+                offset);
+  }
   RET_CHECK_NE(data, MAP_FAILED) << "Failed to map, error: " << strerror(errno);
   RET_CHECK_NE(data, nullptr) << "Failed to map.";
 #ifdef __APPLE__


### PR DESCRIPTION
## Summary

`MemoryMappedFile::Create` currently maps weight files with `PROT_READ | PROT_WRITE | MAP_PRIVATE`. On Linux/Android this is essentially free because the kernel only reserves anonymous backing for pages that are actually written, and the runtime never writes to weight pages in practice. On iOS, however, the kernel's overcommit policy is much stricter: a `PROT_WRITE` mapping is treated as needing immediate VM reservation for the full length, which fails with `ENOMEM` for any model larger than the address-space budget granted to a process without the `com.apple.developer.kernel.extended-virtual-addressing` entitlement.

For a typical 2.5 GB `.litertlm` (e.g. `gemma-4-E2B-it.litertlm`), this manifests as a hard crash inside `odml.infra.LiteRTResourceCalculator` during prefill, with the trace ending at `memory_mapped_file_posix.cc:85` and the message `Failed to map, error: Cannot allocate memory`. This affects every iOS app that loads LiteRT-LM models without the extended-virtual-addressing entitlement (which Apple does not grant to free-tier provisioning profiles, and which third-party apps do not always have access to).

## Change

Map the weight file as `PROT_READ` only. The mapping is created from a file opened with `ScopedFile::Open` (read-only), and weight data is never mutated by the runtime, so dropping `PROT_WRITE` does not change correctness. `PROT_READ|PROT_WRITE` is retained as a fallback if the read-only mmap unexpectedly fails, so any caller that did write to the mapping will still work and only emit a warning.

`MemoryMappedFile::CreateMutable` (used for actual mutable mappings) is unchanged.

## Test plan

- [x] iPhone 14 Pro, iOS 26.4, free-tier signing, gemma-4-E2B-it.litertlm (2.5 GB) via flutter_gemma 0.13.6: previously crashed at \`Cannot allocate memory\`; with this patch the model loads and generates tokens.
- [x] macOS host build (CMake \`make\` preset): no regression.
- [ ] Android arm64 (\`android-arm64\` preset): build unaffected (mapping flags semantically identical for read-only file pages on Linux).