### PR TITLE
c/engine.cc: propagate cache_dir to vision/audio executor settings

### DIFF
--- a/c/engine.cc
+++ b/c/engine.cc
@@ -408,6 +408,14 @@ void litert_lm_engine_settings_set_cache_dir(LiteRtLmEngineSettings* settings,
                                              const char* cache_dir) {
   if (settings && settings->settings) {
     settings->settings->GetMutableMainExecutorSettings().SetCacheDir(cache_dir);
+    if (settings->settings->GetVisionExecutorSettings().has_value()) {
+      settings->settings->GetMutableVisionExecutorSettings()->SetCacheDir(
+          cache_dir);
+    }
+    if (settings->settings->GetAudioExecutorSettings().has_value()) {
+      settings->settings->GetMutableAudioExecutorSettings()->SetCacheDir(
+          cache_dir);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

`litert_lm_engine_settings_set_cache_dir` only set `cache_dir` on the main executor settings. Vision and audio executor settings carry their own `cache_dir` field and were silently left empty, so multimodal models re-ran per-session compile pipelines on every engine create.

This propagates `cache_dir` to vision/audio executors when those optional settings are populated, mirroring what \`runtime/engine/litert_lm_lib.cc\` already does at \`:478\` (vision) and \`:489\` (audio). C API surface unchanged.

Closes #2152.

## What changes

`c/engine.cc` — \`litert_lm_engine_settings_set_cache_dir\` now also calls \`SetCacheDir\` on \`GetMutableVisionExecutorSettings()\` and \`GetMutableAudioExecutorSettings()\` when those optionals have a value:

\`\`\`cpp
if (settings->settings->GetVisionExecutorSettings().has_value()) {
  settings->settings->GetMutableVisionExecutorSettings()->SetCacheDir(cache_dir);
}
if (settings->settings->GetAudioExecutorSettings().has_value()) {
  settings->settings->GetMutableAudioExecutorSettings()->SetCacheDir(cache_dir);
}
\`\`\`

\`+8/-0\`. No-op for text-only models (vision/audio optionals empty), faster cold starts for multimodal models.

## Test plan

- [x] Behaviour parity verified against \`runtime/engine/litert_lm_lib.cc\` flow — both code paths now write the same value to the same field
- [x] No-op when vision/audio optionals are empty (text-only models unaffected)
- [x] flutter_gemma carries this exact patch downstream since v0.13.x — multimodal cold starts (Gemma 3 Nano vision encoder, Gemma 3n audio encoder) skip recompile on second run
- [ ] Upstream CI on this branch

## CLA

Will sign Individual CLA before merge if needed; flagging upfront.