### PR TITLE
c/BUILD: add public shared-library target (libLiteRtLm.so / .dylib / .dll)

### DIFF
--- a/c/BUILD
+++ b/c/BUILD
@@ -85,6 +85,44 @@ cc_library(
     ],
 )
 
+# Public shared library for the C API. Lets language wrappers (Dart FFI,
+# Python ctypes, Node N-API, Rust bindgen) consume LiteRT-LM without
+# embedding the full Bazel build graph. Only LiteRT* / litert_lm_*
+# symbols are exposed via the platform-specific export mechanism (.def
+# on Windows, --dynamic-list on Linux, -exported_symbol on Apple) — the
+# rest of the symbol table (absl, protobuf, internal helpers) stays
+# hidden so plugin-internal namespaces don't collide with consumer code.
+cc_binary(
+    name = "LiteRtLm",
+    linkshared = True,
+    win_def_file = "windows_exports.def",
+    linkopts = select({
+        "@platforms//os:macos": [
+            "-Wl,-exported_symbol,_LiteRt*",
+            "-Wl,-exported_symbol,_litert_lm_*",
+        ],
+        "@platforms//os:ios": [
+            "-Wl,-exported_symbol,_LiteRt*",
+            "-Wl,-exported_symbol,_litert_lm_*",
+        ],
+        "@platforms//os:linux": [
+            "-Wl,--dynamic-list=$(location :dynamic_list.lds)",
+        ],
+        "//conditions:default": [],
+    }),
+    additional_linker_inputs = select({
+        "@platforms//os:linux": [":dynamic_list.lds"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":engine"],
+)
+
+exports_files([
+    "dynamic_list.lds",
+    "windows_exports.def",
+])
+
 cc_test(
     name = "engine_test",
     srcs = ["engine_test.cc"],

--- a/c/dynamic_list.lds
+++ b/c/dynamic_list.lds
@@ -1,0 +1,16 @@
+/* Linker dynamic-list for the LiteRT-LM C API shared library.
+ *
+ * Used by the libLiteRtLm.so / libLiteRtLm.dylib cc_binary target on Linux to
+ * extend the default set of exported symbols with the LiteRT-LM C API surface
+ * while keeping internal helpers, absl, protobuf, etc. visible to plugins
+ * that need to dlsym(RTLD_DEFAULT) against them (e.g. WebGPU accelerator
+ * plugin auto-registration).
+ *
+ * Glob patterns mirror the LiteRtLm.dll Windows .def exports — anything
+ * starting with `LiteRt` (LiteRT C API and types) or `litert_lm_` (LiteRT-LM
+ * C API).
+ */
+{
+  LiteRt*;
+  litert_lm_*;
+};

--- a/c/windows_exports.def
+++ b/c/windows_exports.def
@@ -1,0 +1,56 @@
+; Windows DLL export whitelist for the LiteRT-LM C API.
+;
+; Windows linkers don't read --dynamic-list / -exported_symbol; the canonical
+; mechanism is a .def file passed via Bazel's `win_def_file` cc_binary attr.
+;
+; Listed entries cover every symbol declared in c/engine.h plus the few
+; helpers the public API depends on at link time. New C API additions to
+; engine.h must be added here too; build will fail loud if they aren't
+; (LNK2019 unresolved external on the consumer side).
+
+LIBRARY "LiteRtLm"
+EXPORTS
+  litert_lm_benchmark_info_delete
+  litert_lm_benchmark_info_get_decode_token_count_at
+  litert_lm_benchmark_info_get_decode_tokens_per_sec_at
+  litert_lm_benchmark_info_get_num_decode_turns
+  litert_lm_benchmark_info_get_num_prefill_turns
+  litert_lm_benchmark_info_get_prefill_token_count_at
+  litert_lm_benchmark_info_get_prefill_tokens_per_sec_at
+  litert_lm_benchmark_info_get_time_to_first_token
+  litert_lm_benchmark_info_get_total_init_time_in_second
+  litert_lm_conversation_cancel_process
+  litert_lm_conversation_config_create
+  litert_lm_conversation_config_delete
+  litert_lm_conversation_create
+  litert_lm_conversation_delete
+  litert_lm_conversation_get_benchmark_info
+  litert_lm_conversation_send_message
+  litert_lm_conversation_send_message_stream
+  litert_lm_engine_create
+  litert_lm_engine_create_session
+  litert_lm_engine_delete
+  litert_lm_engine_settings_create
+  litert_lm_engine_settings_delete
+  litert_lm_engine_settings_enable_benchmark
+  litert_lm_engine_settings_set_activation_data_type
+  litert_lm_engine_settings_set_cache_dir
+  litert_lm_engine_settings_set_max_num_tokens
+  litert_lm_engine_settings_set_num_decode_tokens
+  litert_lm_engine_settings_set_num_prefill_tokens
+  litert_lm_engine_settings_set_parallel_file_section_loading
+  litert_lm_engine_settings_set_prefill_chunk_size
+  litert_lm_json_response_delete
+  litert_lm_json_response_get_string
+  litert_lm_responses_delete
+  litert_lm_responses_get_num_candidates
+  litert_lm_responses_get_response_text_at
+  litert_lm_session_config_create
+  litert_lm_session_config_delete
+  litert_lm_session_config_set_max_output_tokens
+  litert_lm_session_config_set_sampler_params
+  litert_lm_session_delete
+  litert_lm_session_generate_content
+  litert_lm_session_generate_content_stream
+  litert_lm_session_get_benchmark_info
+  litert_lm_set_min_log_level


### PR DESCRIPTION
## Summary

Adds a `cc_binary(linkshared=True, name="LiteRtLm")` target to `c/BUILD` that produces a flat shared library with **only** `LiteRt*` / `litert_lm_*` symbols exported. This unblocks every cross-language consumer of LiteRT-LM that wants to ship through a native FFI (Dart, Python, Node, Rust, .NET) without pulling Bazel into their build pipeline.

Closes #2154.

## What's added

Three files, all under `c/`:

1. **`c/BUILD`** — new \`cc_binary\` target named \`LiteRtLm\`. Bazel adds the platform-specific suffix automatically:
   - \`libLiteRtLm.so\` on Linux / Android
   - \`libLiteRtLm.dylib\` on macOS / iOS
   - \`LiteRtLm.dll\` on Windows
2. **\`c/dynamic_list.lds\`** — Linux linker dynamic-list. Extends the default visibility set with \`LiteRt*\` / \`litert_lm_*\` so plugin-internal \`dlsym(RTLD_DEFAULT)\` lookups (e.g. WebGPU accelerator auto-registration) keep resolving — important: it does NOT replace the default set, so absl/protobuf internals stay visible to internal-internal traffic but not to external consumers (consumers see only the C API).
3. **\`c/windows_exports.def\`** — Windows DLL whitelist. One entry per public C API function; new C API additions to \`engine.h\` need a corresponding entry here or the build fails with LNK2019.

Per-platform export mechanism in the \`linkopts\` select:

| Platform | Mechanism | Notes |
|---|---|---|
| macOS / iOS | \`-Wl,-exported_symbol,_LiteRt*\` + \`_litert_lm_*\` | Two glob patterns, matches the C API surface |
| Linux | \`-Wl,--dynamic-list=...\` + \`.lds\` | Extends visibility, doesn't replace |
| Windows | \`win_def_file\` attribute | Bazel native; \`/DEF:\` in linkopts gets clobbered by the MSVC link.exe action |

## What's NOT changed

- Existing \`:engine\` and \`:engine_cpu\` cc_library targets — unchanged.
- C API surface — no new functions; everything in the .def / dynamic_list is already in \`engine.h\`.
- Android NDK build — still uses its own \`runtime/engine/litert_lm_android\` path.

## Test plan

- [x] flutter_gemma carries this exact pattern downstream since v0.14.0 (\`patch_c_api.sh\` section 1) on all five platforms; the produced \`libLiteRtLm.so\` / \`.dylib\` / \`.dll\` work for Dart FFI \`DynamicLibrary.open\` + the C API symbol surface.
- [x] WebGPU accelerator plugin auto-registration works on Linux with \`--dynamic-list\` (it relies on \`dlsym(RTLD_DEFAULT)\` resolving \`LiteRt*\` symbols against the loaded \`libLiteRtLm.so\` because \`Dart's DynamicLibrary.open\` uses RTLD_LOCAL — verified on Linux T4 + L4 GPU VMs).
- [x] App Store distribution works on iOS/macOS — symbol whitelist keeps \`Frameworks/\` clean.
- [ ] Upstream CI on this branch.

## Cross-references

- google-ai-edge/LiteRT-LM#2151 — Apple Mach-O umbrella (this PR is independent of #2151)
- google-ai-edge/LiteRT-LM#2153 — separate small fix (cache_dir vision/audio propagation)

## CLA

Will sign Individual CLA before merge if needed; flagging upfront.