### PR TITLE
c/engine: add litert_lm_engine_settings_set_max_num_images (C API parity for #1686)

### DIFF
--- a/c/engine.cc
+++ b/c/engine.cc
@@ -396,6 +396,15 @@ void litert_lm_engine_settings_set_max_num_tokens(
         max_num_tokens);
   }
 }
+
+void litert_lm_engine_settings_set_max_num_images(
+    LiteRtLmEngineSettings* settings, int max_num_images) {
+  if (settings && settings->settings && max_num_images > 0) {
+    settings->settings->GetMutableMainExecutorSettings().SetMaxNumImages(
+        max_num_images);
+  }
+}
+
 void litert_lm_engine_settings_set_parallel_file_section_loading(
     LiteRtLmEngineSettings* settings, bool parallel_file_section_loading) {
   if (settings && settings->settings) {

--- a/c/engine.h
+++ b/c/engine.h
@@ -262,6 +262,18 @@ LITERT_LM_C_API_EXPORT
 void litert_lm_engine_settings_set_max_num_tokens(
     LiteRtLmEngineSettings* settings, int max_num_tokens);
 
+// Sets the maximum number of images the model can handle in a single
+// session. Required for multimodal vision models (e.g. Gemma 3 Nano,
+// Gemma 4) — without this set on the C API path, vision input is
+// silently ignored and the model hallucinates a response from text
+// alone. Mirrors `EngineConfig.maxNumImages` in the Kotlin API.
+//
+// @param settings The engine settings.
+// @param max_num_images The maximum number of images. Must be > 0.
+LITERT_LM_C_API_EXPORT
+void litert_lm_engine_settings_set_max_num_images(
+    LiteRtLmEngineSettings* settings, int max_num_images);
+
 // Sets whether the engine should load different sections of the litertlm file
 // in parallel. Defaults to true.
 //


### PR DESCRIPTION
## Summary

Adds the C API parity for \`max_num_images\` so multimodal vision models work via the C API path. Without this, vision input is silently dropped on the C API path even though the Kotlin/JVM path was fixed in #1686.

Closes #2156.

## What changes

\`c/engine.h\` — new declaration:

\`\`\`c
LITERT_LM_C_API_EXPORT
void litert_lm_engine_settings_set_max_num_images(
    LiteRtLmEngineSettings* settings, int max_num_images);
\`\`\`

\`c/engine.cc\` — one-line impl that mirrors what \`kotlin/.../jni/litertlm.cc:474\` already does:

\`\`\`cpp
settings->settings->GetMutableMainExecutorSettings().SetMaxNumImages(max_num_images);
\`\`\`

with a \`max_num_images > 0\` guard matching the Kotlin \`require\` precondition.

\`+21/-0\` total. No new behavior on the runtime side — \`SetMaxNumImages\` already exists in the executor settings; this just exposes a setter to the C API surface.

## Test plan

- [x] flutter_gemma carries this exact addition as a downstream patch via \`patch_c_api.sh\` since v0.14.0; multimodal Gemma 3 Nano (vision) on Android / iOS / macOS Native-Assets-bundled FFI works correctly with this setter.
- [x] Behavior parity verified against \`kotlin/.../jni/litertlm.cc:474\` — same field, same conditional, same downstream effect.
- [ ] Upstream CI on this branch.

## Cross-references

- #1686 — original bug (closed when Kotlin was fixed; this PR completes the parity for the C API)
- #2156 — issue this PR closes

If a Windows shared-lib build (#2154 / PR #2155) lands, the new entry will need to be added to \`c/windows_exports.def\`. Happy to follow up there if both land.

## CLA

Will sign Individual CLA before merge if needed; flagging upfront.