### PR TITLE
[codex] add per-turn max_num_patches options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /MODULE.bazel.lock
 /bazel-*
+/.idea/

--- a/c/BUILD
+++ b/c/BUILD
@@ -44,6 +44,7 @@ ENGINE_COMMON_DEPS = [
     "@nlohmann_json//:json",
     "//runtime/conversation",
     "//runtime/conversation:io_types",
+    "//runtime/conversation/model_data_processor:gemma4_data_processor_config",
     "//runtime/engine:engine_factory",
     "//runtime/engine:engine_interface",
     "//runtime/engine:engine_settings",

--- a/c/engine.cc
+++ b/c/engine.cc
@@ -32,6 +32,7 @@
 #include "nlohmann/json.hpp"  // from @nlohmann_json
 #include "runtime/conversation/conversation.h"
 #include "runtime/conversation/io_types.h"
+#include "runtime/conversation/model_data_processor/gemma4_data_processor_config.h"
 #include "runtime/engine/engine.h"
 #include "runtime/engine/engine_factory.h"
 #include "runtime/engine/engine_settings.h"
@@ -97,6 +98,15 @@ litert::lm::OptionalArgs CreateOptionalArgs(const char* extra_context) {
     }
   }
   return optional_args;
+}
+
+// Non-Gemma4 processors ignore unknown DataProcessorArguments variants.
+void ApplySendOptions(litert::lm::OptionalArgs& optional_args,
+                      const LiteRtLmSendOptions* options) {
+  if (options && options->max_num_patches > 0) {
+    optional_args.args = litert::lm::Gemma4DataProcessorArguments{
+        .max_num_patches = options->max_num_patches};
+  }
 }
 
 std::vector<litert::lm::InputData> ToEngineInputData(
@@ -995,6 +1005,63 @@ int litert_lm_conversation_send_message_stream(
   }
 
   litert::lm::OptionalArgs optional_args = CreateOptionalArgs(extra_context);
+
+  absl::Status status = conversation->conversation->SendMessageAsync(
+      json_message, CreateConversationCallback(callback, callback_data),
+      std::move(optional_args));
+
+  if (!status.ok()) {
+    ABSL_LOG(ERROR) << "Failed to start message stream: " << status;
+    return static_cast<int>(status.code());
+  }
+  return 0;
+}
+
+LiteRtLmJsonResponse* litert_lm_conversation_send_message_with_options(
+    LiteRtLmConversation* conversation, const char* message_json,
+    const char* extra_context, const LiteRtLmSendOptions* options) {
+  if (!conversation || !conversation->conversation) {
+    return nullptr;
+  }
+  nlohmann::json json_message =
+      nlohmann::json::parse(message_json, /*cb=*/nullptr,
+                            /*allow_exceptions=*/false);
+  if (json_message.is_discarded()) {
+    ABSL_LOG(ERROR) << "Failed to parse message JSON.";
+    return nullptr;
+  }
+
+  litert::lm::OptionalArgs optional_args = CreateOptionalArgs(extra_context);
+  ApplySendOptions(optional_args, options);
+
+  auto response = conversation->conversation->SendMessage(
+      json_message, std::move(optional_args));
+  if (!response.ok()) {
+    ABSL_LOG(ERROR) << "Failed to send message: " << response.status();
+    return nullptr;
+  }
+  auto* c_response = new LiteRtLmJsonResponse;
+  c_response->json_string = response->dump();
+  return c_response;
+}
+
+int litert_lm_conversation_send_message_stream_with_options(
+    LiteRtLmConversation* conversation, const char* message_json,
+    const char* extra_context, const LiteRtLmSendOptions* options,
+    LiteRtLmStreamCallback callback, void* callback_data) {
+  if (!conversation || !conversation->conversation) {
+    return -1;
+  }
+  nlohmann::json json_message =
+      nlohmann::json::parse(message_json, /*cb=*/nullptr,
+                            /*allow_exceptions=*/false);
+  if (json_message.is_discarded()) {
+    ABSL_LOG(ERROR) << "Failed to parse message JSON.";
+    return -1;
+  }
+
+  litert::lm::OptionalArgs optional_args = CreateOptionalArgs(extra_context);
+  ApplySendOptions(optional_args, options);
 
   absl::Status status = conversation->conversation->SendMessageAsync(
       json_message, CreateConversationCallback(callback, callback_data),

--- a/c/engine.h
+++ b/c/engine.h
@@ -111,6 +111,13 @@ typedef struct {
   int32_t seed;
 } LiteRtLmSamplerParams;
 
+// Options for a single send_message call.
+typedef struct {
+  // Maximum number of image patches for vision processing.
+  // Set to 0 to use the model default.
+  int32_t max_num_patches;
+} LiteRtLmSendOptions;
+
 // Creates a LiteRT LM Session Config.
 // The caller is responsible for destroying the config using
 // `litert_lm_session_config_delete`.
@@ -693,6 +700,21 @@ LiteRtLmJsonResponse* litert_lm_conversation_send_message(
     LiteRtLmConversation* conversation, const char* message_json,
     const char* extra_context);
 
+// Sends a message to the conversation with per-turn options and returns the
+// response. This is a blocking call.
+//
+// @param conversation The conversation to use.
+// @param message_json A JSON string representing the message to send.
+// @param extra_context A JSON string representing the extra context to use.
+// @param options Per-turn send options, or NULL to use defaults.
+// @return A pointer to the JSON response, or NULL on failure. The caller is
+//   responsible for deleting the response using
+//   `litert_lm_json_response_delete`.
+LITERT_LM_C_API_EXPORT
+LiteRtLmJsonResponse* litert_lm_conversation_send_message_with_options(
+    LiteRtLmConversation* conversation, const char* message_json,
+    const char* extra_context, const LiteRtLmSendOptions* options);
+
 // Destroys a LiteRT LM Json Response object.
 //
 // @param response The response to destroy.
@@ -725,6 +747,23 @@ int litert_lm_conversation_send_message_stream(
     LiteRtLmConversation* conversation, const char* message_json,
     const char* extra_context, LiteRtLmStreamCallback callback,
     void* callback_data);
+
+// Sends a message to the conversation with per-turn options and streams the
+// response via a callback. This is a non-blocking call.
+//
+// @param conversation The conversation to use.
+// @param message_json A JSON string representing the message to send.
+// @param extra_context A JSON string representing the extra context to use.
+// @param options Per-turn send options, or NULL to use defaults.
+// @param callback The callback function to receive response chunks.
+// @param callback_data A pointer to user data that will be passed to the
+// callback.
+// @return 0 on success, non-zero on failure to start the stream.
+LITERT_LM_C_API_EXPORT
+int litert_lm_conversation_send_message_stream_with_options(
+    LiteRtLmConversation* conversation, const char* message_json,
+    const char* extra_context, const LiteRtLmSendOptions* options,
+    LiteRtLmStreamCallback callback, void* callback_data);
 
 // Renders the message into a string according to the template.
 //

--- a/c/engine_test.cc
+++ b/c/engine_test.cc
@@ -1114,6 +1114,77 @@ TEST(EngineCTest, SessionGenerateContentStreamAndCancel) {
                                      testing::HasSubstr("CANCELLED")));
 }
 
+TEST(EngineCTest, ConversationSendMessageWithOptions) {
+  const std::string task_path = GetTestdataPath(
+      "litert_lm/runtime/testdata/test_lm_new_metadata.task");
+
+  EngineSettingsPtr settings(
+      litert_lm_engine_settings_create(task_path.c_str(), "cpu",
+                                       /* vision_backend_str */ nullptr,
+                                       /* audio_backend_str */ nullptr),
+      &litert_lm_engine_settings_delete);
+  ASSERT_NE(settings, nullptr);
+  litert_lm_engine_settings_set_max_num_tokens(settings.get(), 16);
+
+  EnginePtr engine(litert_lm_engine_create(settings.get()),
+                   &litert_lm_engine_delete);
+  ASSERT_NE(engine, nullptr);
+
+  ConversationPtr conversation(
+      litert_lm_conversation_create(engine.get(),
+                                    /*conversation_config=*/nullptr),
+      &litert_lm_conversation_delete);
+  ASSERT_NE(conversation, nullptr);
+
+  const char* message_json =
+      R"({"role": "user", "content": [{"type": "text", "text": "Hello"}]})";
+  LiteRtLmSendOptions options{.max_num_patches = 630};
+  JsonResponsePtr response(
+      litert_lm_conversation_send_message_with_options(
+          conversation.get(), message_json, /*extra_context=*/nullptr, &options),
+      &litert_lm_json_response_delete);
+  ASSERT_NE(response, nullptr);
+
+  const char* response_str = litert_lm_json_response_get_string(response.get());
+  ASSERT_NE(response_str, nullptr);
+  EXPECT_GT(strlen(response_str), 0);
+}
+
+TEST(EngineCTest, ConversationSendMessageStreamWithOptions) {
+  const std::string task_path = GetTestdataPath(
+      "litert_lm/runtime/testdata/test_lm_new_metadata.task");
+
+  EngineSettingsPtr settings(
+      litert_lm_engine_settings_create(task_path.c_str(), "cpu",
+                                       /* vision_backend_str */ nullptr,
+                                       /* audio_backend_str */ nullptr),
+      &litert_lm_engine_settings_delete);
+  ASSERT_NE(settings, nullptr);
+  litert_lm_engine_settings_set_max_num_tokens(settings.get(), 16);
+
+  EnginePtr engine(litert_lm_engine_create(settings.get()),
+                   &litert_lm_engine_delete);
+  ASSERT_NE(engine, nullptr);
+
+  ConversationPtr conversation(
+      litert_lm_conversation_create(engine.get(),
+                                    /*conversation_config=*/nullptr),
+      &litert_lm_conversation_delete);
+  ASSERT_NE(conversation, nullptr);
+
+  const char* message_json =
+      R"({"role": "user", "content": [{"type": "text", "text": "Hello"}]})";
+  LiteRtLmSendOptions options{.max_num_patches = 630};
+  StreamCallbackData callback_data;
+  int result = litert_lm_conversation_send_message_stream_with_options(
+      conversation.get(), message_json, /*extra_context=*/nullptr, &options,
+      &StreamCallback, &callback_data);
+  ASSERT_EQ(result, 0);
+
+  callback_data.done.WaitForNotification();
+  EXPECT_GT(callback_data.response.length(), 0);
+}
+
 TEST(EngineCTest, ConversationSendMessageStream) {
   const std::string task_path = GetTestdataPath(
       "litert_lm/runtime/testdata/test_lm_new_metadata.task");

--- a/kotlin/java/com/google/ai/edge/litertlm/Conversation.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/Conversation.kt
@@ -92,7 +92,11 @@ class Conversation(
    *   invalid response, or if the tool call limit is exceeded.
    * @throws LiteRtLmJniException if an error occurs during the native call.
    */
-  fun sendMessage(message: Message, extraContext: Map<String, Any> = emptyMap()): Message {
+  fun sendMessage(
+    message: Message,
+    extraContext: Map<String, Any> = emptyMap(),
+    options: SendOptions = SendOptions(),
+  ): Message {
     checkIsAlive()
 
     var currentMessageJson = message.toJson()
@@ -100,7 +104,12 @@ class Conversation(
 
     for (i in 0..<RECURRING_TOOL_CALL_LIMIT) {
       val responseJsonString =
-        LiteRtLmJni.nativeSendMessage(handle, currentMessageJson.toString(), extraContextJsonString)
+        if (options.maxNumPatches != null) {
+          LiteRtLmJni.nativeSendMessageWithOptions(
+            handle, currentMessageJson.toString(), extraContextJsonString, options.maxNumPatches)
+        } else {
+          LiteRtLmJni.nativeSendMessage(handle, currentMessageJson.toString(), extraContextJsonString)
+        }
       val responseJsonObject = JsonParser.parseString(responseJsonString).asJsonObject
 
       if (responseJsonObject.has("tool_calls")) {
@@ -133,8 +142,12 @@ class Conversation(
    *   invalid response, or if the tool call limit is exceeded.
    * @throws LiteRtLmJniException if an error occurs during the native call.
    */
-  fun sendMessage(contents: Contents, extraContext: Map<String, Any> = emptyMap()): Message {
-    return sendMessage(Message.user(contents), extraContext)
+  fun sendMessage(
+    contents: Contents,
+    extraContext: Map<String, Any> = emptyMap(),
+    options: SendOptions = SendOptions(),
+  ): Message {
+    return sendMessage(Message.user(contents), extraContext, options)
   }
 
   /**
@@ -152,8 +165,12 @@ class Conversation(
    *   invalid response, or if the tool call limit is exceeded.
    * @throws LiteRtLmJniException if an error occurs during the native call.
    */
-  fun sendMessage(text: String, extraContext: Map<String, Any> = emptyMap()): Message =
-    sendMessage(Contents.of(text), extraContext)
+  fun sendMessage(
+    text: String,
+    extraContext: Map<String, Any> = emptyMap(),
+    options: SendOptions = SendOptions(),
+  ): Message =
+    sendMessage(Contents.of(text), extraContext, options)
 
   /**
    * Send a message to the model and returns the response async with a callback.
@@ -173,18 +190,29 @@ class Conversation(
     message: Message,
     callback: MessageCallback,
     extraContext: Map<String, Any> = emptyMap(),
+    options: SendOptions = SendOptions(),
   ) {
     checkIsAlive()
 
     val extraContextJsonString = extraContext.toJsonObject().toString()
 
     val jniCallback = JniMessageCallbackImpl(callback)
-    LiteRtLmJni.nativeSendMessageAsync(
-      handle,
-      message.toJson().toString(),
-      extraContextJsonString,
-      jniCallback,
-    )
+    if (options.maxNumPatches != null) {
+      LiteRtLmJni.nativeSendMessageAsyncWithOptions(
+        handle,
+        message.toJson().toString(),
+        extraContextJsonString,
+        options.maxNumPatches,
+        jniCallback,
+      )
+    } else {
+      LiteRtLmJni.nativeSendMessageAsync(
+        handle,
+        message.toJson().toString(),
+        extraContextJsonString,
+        jniCallback,
+      )
+    }
   }
 
   /**
@@ -205,7 +233,8 @@ class Conversation(
     contents: Contents,
     callback: MessageCallback,
     extraContext: Map<String, Any> = emptyMap(),
-  ) = sendMessageAsync(Message.user(contents), callback, extraContext)
+    options: SendOptions = SendOptions(),
+  ) = sendMessageAsync(Message.user(contents), callback, extraContext, options)
 
   /**
    * Send a text to the model and returns the response async with a callback.
@@ -225,7 +254,8 @@ class Conversation(
     text: String,
     callback: MessageCallback,
     extraContext: Map<String, Any> = emptyMap(),
-  ) = sendMessageAsync(Contents.of(text), callback, extraContext)
+    options: SendOptions = SendOptions(),
+  ) = sendMessageAsync(Contents.of(text), callback, extraContext, options)
 
   /**
    * Sends a message to the model and returns the response async as a [Flow].
@@ -244,6 +274,7 @@ class Conversation(
   fun sendMessageAsync(
     message: Message,
     extraContext: Map<String, Any> = emptyMap(),
+    options: SendOptions = SendOptions(),
   ): Flow<Message> = callbackFlow {
     sendMessageAsync(
       message,
@@ -261,6 +292,7 @@ class Conversation(
         }
       },
       extraContext,
+      options,
     )
     awaitClose {}
   }
@@ -282,7 +314,8 @@ class Conversation(
   fun sendMessageAsync(
     contents: Contents,
     extraContext: Map<String, Any> = emptyMap(),
-  ): Flow<Message> = sendMessageAsync(Message.user(contents), extraContext)
+    options: SendOptions = SendOptions(),
+  ): Flow<Message> = sendMessageAsync(Message.user(contents), extraContext, options)
 
   /**
    * Sends a text to the model and returns the response async as a [Flow].
@@ -298,8 +331,12 @@ class Conversation(
    * @throws IllegalStateException if the conversation has already been closed or the content is
    *   empty.
    */
-  fun sendMessageAsync(text: String, extraContext: Map<String, Any> = emptyMap()): Flow<Message> =
-    sendMessageAsync(Contents.of(text), extraContext)
+  fun sendMessageAsync(
+    text: String,
+    extraContext: Map<String, Any> = emptyMap(),
+    options: SendOptions = SendOptions(),
+  ): Flow<Message> =
+    sendMessageAsync(Contents.of(text), extraContext, options)
 
   private fun handleToolCalls(toolCallsJsonObject: JsonObject): JsonObject {
     val toolCallsJSONArray = toolCallsJsonObject.getAsJsonArray("tool_calls")

--- a/kotlin/java/com/google/ai/edge/litertlm/LiteRtLmJni.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/LiteRtLmJni.kt
@@ -247,6 +247,39 @@ internal object LiteRtLmJni {
   ): String
 
   /**
+   * Send message from the given input data synchronously, with per-turn options.
+   *
+   * @param conversationPointer A pointer to the native conversation instance.
+   * @param messageJsonString The message to be processed by the native conversation instance.
+   * @param extraContextJsonString The extra context in JSON string format.
+   * @param maxNumPatches Maximum number of image patches for vision processing. 0 = model default.
+   * @return The response message in JSON string format.
+   */
+  external fun nativeSendMessageWithOptions(
+    conversationPointer: Long,
+    messageJsonString: String,
+    extraContextJsonString: String,
+    maxNumPatches: Int,
+  ): String
+
+  /**
+   * Send message from the given input data asynchronously, with per-turn options.
+   *
+   * @param conversationPointer A pointer to the native conversation instance.
+   * @param messageJsonString The message to be processed by the native conversation instance.
+   * @param extraContextJsonString The extra context in JSON string format.
+   * @param maxNumPatches Maximum number of image patches for vision processing. 0 = model default.
+   * @param callback The callback to receive the streaming responses.
+   */
+  external fun nativeSendMessageAsyncWithOptions(
+    conversationPointer: Long,
+    messageJsonString: String,
+    extraContextJsonString: String,
+    maxNumPatches: Int,
+    callback: JniMessageCallback,
+  )
+
+  /**
    * Cancels the ongoing conversation process.
    *
    * @param conversationPointer A pointer to the native conversation instance.

--- a/kotlin/java/com/google/ai/edge/litertlm/SendOptions.kt
+++ b/kotlin/java/com/google/ai/edge/litertlm/SendOptions.kt
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.ai.edge.litertlm
+
+/**
+ * Per-turn options for [Conversation.sendMessage] and
+ * [Conversation.sendMessageAsync].
+ *
+ * @param maxNumPatches Maximum number of image patches for vision processing.
+ *   Controls the token budget tradeoff between inference speed and image
+ *   accuracy. Typical values: 630, 1260, 2520, 5040, 10080 (corresponding to
+ *   token budgets of 70, 140, 280, 560, 1120). Null uses the model default.
+ */
+data class SendOptions(
+  val maxNumPatches: Int? = null,
+)

--- a/kotlin/java/com/google/ai/edge/litertlm/jni/BUILD
+++ b/kotlin/java/com/google/ai/edge/litertlm/jni/BUILD
@@ -38,6 +38,7 @@ cc_binary(
         "//runtime/components:prompt_template",
         "//runtime/conversation",
         "//runtime/conversation:io_types",
+        "//runtime/conversation/model_data_processor:gemma4_data_processor_config",
         "//runtime/engine:engine_factory",
         "//runtime/engine:engine_interface",
         "//runtime/engine:engine_settings",

--- a/kotlin/java/com/google/ai/edge/litertlm/jni/litertlm.cc
+++ b/kotlin/java/com/google/ai/edge/litertlm/jni/litertlm.cc
@@ -34,6 +34,7 @@
 #include "runtime/components/prompt_template.h"
 #include "runtime/conversation/conversation.h"
 #include "runtime/conversation/io_types.h"
+#include "runtime/conversation/model_data_processor/gemma4_data_processor_config.h"
 #include "runtime/engine/engine.h"
 #include "runtime/engine/engine_factory.h"
 #include "runtime/engine/engine_settings.h"
@@ -925,24 +926,22 @@ LITERTLM_JNIEXPORT void JNICALL JNI_METHOD(nativeDeleteConversation)(
   delete reinterpret_cast<Conversation*>(conversation_pointer);
 }
 
-LITERTLM_JNIEXPORT void JNICALL JNI_METHOD(nativeSendMessageAsync)(
-    JNIEnv* env, jclass thiz, jlong conversation_pointer,
-    jstring messageJSONString, jstring extraContextJsonString,
-    jobject callback) {
+static void SendMessageAsyncImpl(JNIEnv* env, Conversation* conversation,
+                                  jstring messageJSONString,
+                                  jstring extraContextJsonString,
+                                  litert::lm::OptionalArgs optional_args,
+                                  jobject callback,
+                                  const std::string& caller_name) {
   JavaVM* jvm = nullptr;
   if (env->GetJavaVM(&jvm) != JNI_OK) {
     ThrowLiteRtLmJniException(env, "Failed to get JavaVM");
     return;
   }
 
-  Conversation* conversation =
-      reinterpret_cast<Conversation*>(conversation_pointer);
-
   const char* json_chars = env->GetStringUTFChars(messageJSONString, nullptr);
   litert::lm::Message json_message = nlohmann::ordered_json::parse(json_chars);
   env->ReleaseStringUTFChars(messageJSONString, json_chars);
 
-  litert::lm::OptionalArgs optional_args;
   nlohmann::ordered_json extra_context =
       GetExtraContextJson(env, extraContextJsonString);
   if (!extra_context.is_null() && !extra_context.empty()) {
@@ -980,7 +979,6 @@ LITERTLM_JNIEXPORT void JNICALL JNI_METHOD(nativeSendMessageAsync)(
         JNIEnv* env = GetJniEnvAndAttach(jvm, &attached);
         if (!env) return;
 
-        // This lambda is to clean up the global reference.
         auto on_done_fn = [jvm, callback_global, terminal_reached]() {
           if (*terminal_reached) return;
           *terminal_reached = true;
@@ -1025,8 +1023,19 @@ LITERTLM_JNIEXPORT void JNICALL JNI_METHOD(nativeSendMessageAsync)(
 
   if (!status.ok()) {
     ThrowLiteRtLmJniException(
-        env, "Failed to start nativeSendMessageAsync: " + status.ToString());
+        env, "Failed to start " + caller_name + ": " + status.ToString());
   }
+}
+
+LITERTLM_JNIEXPORT void JNICALL JNI_METHOD(nativeSendMessageAsync)(
+    JNIEnv* env, jclass thiz, jlong conversation_pointer,
+    jstring messageJSONString, jstring extraContextJsonString,
+    jobject callback) {
+  Conversation* conversation =
+      reinterpret_cast<Conversation*>(conversation_pointer);
+  SendMessageAsyncImpl(env, conversation, messageJSONString,
+                       extraContextJsonString, litert::lm::OptionalArgs{},
+                       callback, "nativeSendMessageAsync");
 }
 
 LITERTLM_JNIEXPORT jstring JNICALL JNI_METHOD(nativeSendMessage)(
@@ -1055,6 +1064,56 @@ LITERTLM_JNIEXPORT jstring JNICALL JNI_METHOD(nativeSendMessage)(
   }
 
   return NewStringStandardUTF(env, response->dump());
+}
+
+LITERTLM_JNIEXPORT jstring JNICALL JNI_METHOD(nativeSendMessageWithOptions)(
+    JNIEnv* env, jclass thiz, jlong conversation_pointer,
+    jstring messageJSONString, jstring extraContextJsonString,
+    jint maxNumPatches) {
+  Conversation* conversation =
+      reinterpret_cast<Conversation*>(conversation_pointer);
+
+  const char* json_chars = env->GetStringUTFChars(messageJSONString, nullptr);
+  litert::lm::Message json_message = nlohmann::ordered_json::parse(json_chars);
+  env->ReleaseStringUTFChars(messageJSONString, json_chars);
+
+  litert::lm::OptionalArgs optional_args;
+  nlohmann::ordered_json extra_context =
+      GetExtraContextJson(env, extraContextJsonString);
+  if (!extra_context.is_null() && !extra_context.empty()) {
+    optional_args.extra_context = extra_context;
+  }
+  if (maxNumPatches > 0) {
+    optional_args.args = litert::lm::Gemma4DataProcessorArguments{
+        .max_num_patches = static_cast<int>(maxNumPatches)};
+  }
+
+  auto response =
+      conversation->SendMessage(json_message, std::move(optional_args));
+  if (!response.ok()) {
+    ThrowLiteRtLmJniException(
+        env, "Failed to call nativeSendMessageWithOptions: " +
+                 response.status().ToString());
+    return nullptr;
+  }
+
+  return NewStringStandardUTF(env, response->dump());
+}
+
+LITERTLM_JNIEXPORT void JNICALL JNI_METHOD(nativeSendMessageAsyncWithOptions)(
+    JNIEnv* env, jclass thiz, jlong conversation_pointer,
+    jstring messageJSONString, jstring extraContextJsonString,
+    jint maxNumPatches, jobject callback) {
+  Conversation* conversation =
+      reinterpret_cast<Conversation*>(conversation_pointer);
+  litert::lm::OptionalArgs optional_args;
+  if (maxNumPatches > 0) {
+    optional_args.args = litert::lm::Gemma4DataProcessorArguments{
+        .max_num_patches = static_cast<int>(maxNumPatches)};
+  }
+  SendMessageAsyncImpl(env, conversation, messageJSONString,
+                       extraContextJsonString, std::move(optional_args),
+                       callback, "nativeSendMessageAsyncWithOptions");
 }
 
 LITERTLM_JNIEXPORT void JNICALL JNI_METHOD(nativeConversationCancelProcess)(

--- a/python/litert_lm/_ffi.py
+++ b/python/litert_lm/_ffi.py
@@ -43,6 +43,14 @@ class LiteRtLmSamplerParams(ctypes.Structure):
   ]
 
 
+class LiteRtLmSendOptions(ctypes.Structure):
+  _fields_ = [
+      # Maximum number of image patches for vision processing.
+      # Set to 0 to use the model default.
+      ("max_num_patches", ctypes.c_int),
+  ]
+
+
 class LiteRtLmInputData(ctypes.Structure):
   _fields_ = [
       ("type", ctypes.c_int),
@@ -285,6 +293,22 @@ def _setup_lib_signatures(lib):
       ctypes.c_void_p,
       c_string_p,
       c_string_p,
+      STREAM_CALLBACK_TYPE,
+      ctypes.c_void_p,
+  ]
+  lib.litert_lm_conversation_send_message_with_options.restype = ctypes.c_void_p
+  lib.litert_lm_conversation_send_message_with_options.argtypes = [
+      ctypes.c_void_p,
+      c_string_p,
+      c_string_p,
+      ctypes.POINTER(LiteRtLmSendOptions),
+  ]
+  lib.litert_lm_conversation_send_message_stream_with_options.restype = ctypes.c_int
+  lib.litert_lm_conversation_send_message_stream_with_options.argtypes = [
+      ctypes.c_void_p,
+      c_string_p,
+      c_string_p,
+      ctypes.POINTER(LiteRtLmSendOptions),
       STREAM_CALLBACK_TYPE,
       ctypes.c_void_p,
   ]

--- a/python/litert_lm/conversation.py
+++ b/python/litert_lm/conversation.py
@@ -14,12 +14,14 @@
 """Conversation wrapper for LiteRT-LM."""
 
 import collections.abc
+import ctypes
 import json
 import logging
 import queue
 from typing import Any
 
 from . import interfaces
+from ._ffi import LiteRtLmSendOptions
 from ._ffi import STREAM_CALLBACK_TYPE
 
 
@@ -113,7 +115,10 @@ class Conversation(interfaces.AbstractConversation):
     return tool_responses
 
   def send_message(
-      self, message: str | collections.abc.Mapping[str, Any]
+      self,
+      message: str | collections.abc.Mapping[str, Any],
+      *,
+      max_num_patches: int | None = None,
   ) -> collections.abc.Mapping[str, Any]:
     current_message = (
         message
@@ -125,9 +130,15 @@ class Conversation(interfaces.AbstractConversation):
       msg_json = json.dumps(current_message)
       ctx_json = json.dumps(getattr(self, "extra_context", {}))
 
-      resp_ptr = self._lib.litert_lm_conversation_send_message(
-          self._ptr, msg_json, ctx_json
-      )
+      if max_num_patches is not None:
+        options = LiteRtLmSendOptions(max_num_patches=max_num_patches)
+        resp_ptr = self._lib.litert_lm_conversation_send_message_with_options(
+            self._ptr, msg_json, ctx_json, ctypes.byref(options)
+        )
+      else:
+        resp_ptr = self._lib.litert_lm_conversation_send_message(
+            self._ptr, msg_json, ctx_json
+        )
       if not resp_ptr:
         raise RuntimeError("litert_lm_conversation_send_message failed")
 
@@ -147,7 +158,10 @@ class Conversation(interfaces.AbstractConversation):
       current_message = tool_responses
 
   def send_message_async(
-      self, message: str | collections.abc.Mapping[str, Any]
+      self,
+      message: str | collections.abc.Mapping[str, Any],
+      *,
+      max_num_patches: int | None = None,
   ) -> collections.abc.Iterator[collections.abc.Mapping[str, Any]]:
     current_message = (
         message
@@ -169,13 +183,25 @@ class Conversation(interfaces.AbstractConversation):
 
       c_callback = STREAM_CALLBACK_TYPE(callback)
       self._current_callback = c_callback
-      res = self._lib.litert_lm_conversation_send_message_stream(
-          self._ptr,
-          msg_json,
-          ctx_json,
-          c_callback,
-          None,
-      )
+
+      if max_num_patches is not None:
+        options = LiteRtLmSendOptions(max_num_patches=max_num_patches)
+        res = self._lib.litert_lm_conversation_send_message_stream_with_options(
+            self._ptr,
+            msg_json,
+            ctx_json,
+            ctypes.byref(options),
+            c_callback,
+            None,
+        )
+      else:
+        res = self._lib.litert_lm_conversation_send_message_stream(
+            self._ptr,
+            msg_json,
+            ctx_json,
+            c_callback,
+            None,
+        )
       if res != 0:
         raise RuntimeError("litert_lm_conversation_send_message_stream failed")
 

--- a/python/litert_lm/interfaces.py
+++ b/python/litert_lm/interfaces.py
@@ -318,13 +318,19 @@ class AbstractConversation(abc.ABC):
 
   @abc.abstractmethod
   def send_message(
-      self, message: str | collections.abc.Mapping[str, Any]
+      self,
+      message: str | collections.abc.Mapping[str, Any],
+      *,
+      max_num_patches: int | None = None,
   ) -> collections.abc.Mapping[str, Any]:
     """Sends a message and returns the response.
 
     Args:
         message: The input message to send to the model. Example: "Hello" or
           {"role": "user", "content": "Hello"}.
+        max_num_patches: Maximum number of image patches for vision processing.
+          Controls the token budget tradeoff between inference speed and image
+          accuracy. None uses the model default.
 
     Returns:
         A dictionary containing the model's response. The structure is:
@@ -333,13 +339,19 @@ class AbstractConversation(abc.ABC):
 
   @abc.abstractmethod
   def send_message_async(
-      self, message: str | collections.abc.Mapping[str, Any]
+      self,
+      message: str | collections.abc.Mapping[str, Any],
+      *,
+      max_num_patches: int | None = None,
   ) -> collections.abc.Iterator[collections.abc.Mapping[str, Any]]:
     """Sends a message and streams the response.
 
     Args:
         message: The input message to send to the model. Example: "Hello" or
           {"role": "user", "content": "Hello"}.
+        max_num_patches: Maximum number of image patches for vision processing.
+          Controls the token budget tradeoff between inference speed and image
+          accuracy. None uses the model default.
 
     Returns:
         An iterator yielding dictionaries containing chunks of the model's


### PR DESCRIPTION
## What
- Adds per-turn `max_num_patches` support in the C API, JNI/Kotlin bindings, and Python bindings.
- Threads the value into the native conversation path as Gemma 4 data-processor arguments.
- Keeps existing behavior unchanged when the option is omitted or set to the model default.

## Why
- Gemma vision workflows need a per-request way to tune the image token budget without changing the model-wide configuration.
- This keeps the API aligned with the image capability guidance while letting callers trade off speed, cost, and image fidelity on a single turn.
- Relevant docs: https://ai.google.dev/gemma/docs/capabilities/vision/prompt-with-visual-data?utm_source=openai

## Validation
- Added C++ coverage for blocking and streaming conversation sends with options.
- The branch was pushed successfully; no additional build was run in this publish step.
