### PR TITLE
fix(apple): forward runtime library dir to LiteRT

### DIFF
--- a/python/litert_lm/BUILD
+++ b/python/litert_lm/BUILD
@@ -34,6 +34,7 @@ cc_binary(
     features = ["-legacy_whole_archive"],
     linkopts = select({
         "@platforms//os:macos": [],
+        "@platforms//os:ios": [],
         "@platforms//os:windows": [],
         "//conditions:default": [
             # Report unresolved symbol references as errors during linking.

--- a/runtime/util/litert_util.cc
+++ b/runtime/util/litert_util.cc
@@ -53,6 +53,16 @@ absl::StatusOr<OwnedEnvironment> CreateEnvironment(
     }
   }
 
+  if ((backend == Backend::CPU || backend == Backend::GPU) &&
+      !main_executor_settings.GetLitertDispatchLibDir().empty()) {
+    env_options.push_back(::litert::EnvironmentOptions::Option{
+        ::litert::EnvironmentOptions::Tag::kRuntimeLibraryDir,
+        main_executor_settings.GetLitertDispatchLibDir()});
+    ABSL_LOG(INFO) << "Setting LiteRT runtime library path from "
+                      "main_executor_settings: "
+                   << main_executor_settings.GetLitertDispatchLibDir();
+  }
+
   bool uses_npu = (backend == Backend::NPU ||
                    (engine_settings.GetVisionExecutorSettings().has_value() &&
                     engine_settings.GetVisionExecutorSettings()->GetBackend() ==


### PR DESCRIPTION
## Summary
- forward LiteRT-LM's `litert_dispatch_lib_dir` setting into LiteRT `EnvironmentOptions::Tag::kRuntimeLibraryDir`
- after the SessionAdvanced transition this lives in the single environment-creation path, `runtime/util/litert_util.cc` `CreateEnvironment()` (originally applied in both engine impls; rebased after upstream consolidated/removed those files)
- applies on the CPU/GPU backends only; the NPU path already forwards the dir as `kDispatchLibraryDir`
- keep iOS link options empty so desktop link options do not leak onto iOS

## Why
Apple app bundles embed accelerator sidecars as signed frameworks under the app `Frameworks` directory. Without forwarding the runtime library directory, LiteRT's GPU registry falls back to basename loading and cannot find or register the Metal accelerator on iOS.

## Validation
- Used in b4 iPhone 16 Pro LiteRT GPU validation with `GPU Metal` registered and Gemma 4 E2B decode completing at 40+ tok/s in a cool short smoke.
- Sustained b4 1000-turn provider soak completed on iPhone with LiteRT GPU selected.