### PR TITLE
Support text LoRA sessions through ResourceManager

### DIFF
--- a/c/engine.cc
+++ b/c/engine.cc
@@ -322,6 +322,7 @@ int litert_lm_session_config_set_lora_path(LiteRtLmSessionConfig* config,
   }
   config->config->SetScopedLoraFile(
       std::make_shared<litert::lm::ScopedFile>(std::move(*lora_file)));
+  config->config->SetLoraPath(std::string(path_view.data(), path_view.size()));
   return 0;
 }
 
@@ -341,6 +342,8 @@ int litert_lm_session_config_set_audio_lora_path(LiteRtLmSessionConfig* config,
   }
   config->config->SetAudioScopedLoraFile(
       std::make_shared<litert::lm::ScopedFile>(std::move(*lora_file)));
+  config->config->SetAudioLoraPath(
+      std::string(path_view.data(), path_view.size()));
   return 0;
 }
 

--- a/c/engine_test.cc
+++ b/c/engine_test.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <fstream>
 #include <memory>
 #include <optional>
 #include <string>
@@ -328,6 +329,44 @@ TEST(EngineCTest, CreateSessionConfigWithApplyPromptTemplate) {
 
   litert_lm_session_config_set_apply_prompt_template(config.get(), true);
   EXPECT_TRUE(config->config->GetApplyPromptTemplateInSession());
+}
+
+TEST(EngineCTest, SetSessionConfigLoraPathStoresFileAndPath) {
+  SessionConfigPtr config(litert_lm_session_config_create(),
+                          &litert_lm_session_config_delete);
+  ASSERT_NE(config, nullptr);
+  const std::string lora_path =
+      ::testing::TempDir() + "/set_session_config_lora_path.tflite";
+  {
+    std::ofstream ofs(lora_path);
+    ofs << "lora";
+  }
+
+  EXPECT_EQ(
+      litert_lm_session_config_set_lora_path(config.get(), lora_path.c_str()),
+      0);
+  EXPECT_NE(config->config->GetScopedLoraFile(), nullptr);
+  ASSERT_TRUE(config->config->GetLoraPath().has_value());
+  EXPECT_EQ(*config->config->GetLoraPath(), lora_path);
+}
+
+TEST(EngineCTest, SetSessionConfigAudioLoraPathStoresFileAndPath) {
+  SessionConfigPtr config(litert_lm_session_config_create(),
+                          &litert_lm_session_config_delete);
+  ASSERT_NE(config, nullptr);
+  const std::string lora_path =
+      ::testing::TempDir() + "/set_session_config_audio_lora_path.tflite";
+  {
+    std::ofstream ofs(lora_path);
+    ofs << "audio lora";
+  }
+
+  EXPECT_EQ(litert_lm_session_config_set_audio_lora_path(config.get(),
+                                                         lora_path.c_str()),
+            0);
+  EXPECT_NE(config->config->GetAudioScopedLoraFile(), nullptr);
+  ASSERT_TRUE(config->config->GetAudioLoraPath().has_value());
+  EXPECT_EQ(*config->config->GetAudioLoraPath(), lora_path);
 }
 
 TEST(EngineCTest, CreateConversationConfig) {

--- a/runtime/engine/engine_settings.cc
+++ b/runtime/engine/engine_settings.cc
@@ -734,6 +734,14 @@ void SessionConfig::SetScopedLoraFile(
   scoped_lora_file_ = std::move(scoped_lora_file);
 }
 
+const std::optional<std::string>& SessionConfig::GetLoraPath() const {
+  return lora_path_;
+}
+
+void SessionConfig::SetLoraPath(std::optional<std::string> lora_path) {
+  lora_path_ = std::move(lora_path);
+}
+
 std::shared_ptr<ScopedFile> SessionConfig::GetAudioScopedLoraFile() const {
   return scoped_audio_lora_file_;
 }
@@ -741,6 +749,15 @@ std::shared_ptr<ScopedFile> SessionConfig::GetAudioScopedLoraFile() const {
 void SessionConfig::SetAudioScopedLoraFile(
     std::shared_ptr<ScopedFile> scoped_audio_lora_file) {
   scoped_audio_lora_file_ = std::move(scoped_audio_lora_file);
+}
+
+const std::optional<std::string>& SessionConfig::GetAudioLoraPath() const {
+  return audio_lora_path_;
+}
+
+void SessionConfig::SetAudioLoraPath(
+    std::optional<std::string> audio_lora_path) {
+  audio_lora_path_ = std::move(audio_lora_path);
 }
 
 std::ostream& operator<<(std::ostream& os, const SessionConfig& config) {
@@ -768,8 +785,11 @@ std::ostream& operator<<(std::ostream& os, const SessionConfig& config) {
   os << "  ScopedLoraFile: "
      << (config.GetScopedLoraFile() != nullptr ? "Present" : "Not present")
      << std::endl;
+  os << "  LoraPath: " << config.GetLoraPath().value_or("Not set") << std::endl;
   os << "  ScopedAudioLoraFile: "
      << (config.GetAudioScopedLoraFile() != nullptr ? "Present" : "Not present")
+     << std::endl;
+  os << "  AudioLoraPath: " << config.GetAudioLoraPath().value_or("Not set")
      << std::endl;
   return os;
 }

--- a/runtime/engine/engine_settings.h
+++ b/runtime/engine/engine_settings.h
@@ -256,11 +256,21 @@ class SessionConfig {
   std::shared_ptr<ScopedFile> GetScopedLoraFile() const;
   void SetScopedLoraFile(std::shared_ptr<ScopedFile> scoped_lora_file);
 
+  // LoRA path:
+  // Getters for the LoRA path.
+  const std::optional<std::string>& GetLoraPath() const;
+  void SetLoraPath(std::optional<std::string> lora_path);
+
   // Scoped Audio LoRA file:
   // Getters for the scoped audio LoRA file.
   std::shared_ptr<ScopedFile> GetAudioScopedLoraFile() const;
   void SetAudioScopedLoraFile(
       std::shared_ptr<ScopedFile> scoped_audio_lora_file);
+
+  // Audio LoRA path:
+  // Getters for the audio LoRA path.
+  const std::optional<std::string>& GetAudioLoraPath() const;
+  void SetAudioLoraPath(std::optional<std::string> audio_lora_path);
 
   // The maximum number of tokens to generate in a single request:
   // Getters for the max output tokens.
@@ -317,8 +327,14 @@ class SessionConfig {
   // Scoped file for the LoRA weights.
   std::shared_ptr<ScopedFile> scoped_lora_file_;
 
+  // Path for the LoRA weights.
+  std::optional<std::string> lora_path_;
+
   // Scoped file for the Audio LoRA weights.
   std::shared_ptr<ScopedFile> scoped_audio_lora_file_;
+
+  // Path for the Audio LoRA weights.
+  std::optional<std::string> audio_lora_path_;
 
   // The maximum number of tokens to generate in a single request. This limits
   // the number of decoding steps for a request, as opposed to

--- a/runtime/engine/engine_settings_test.cc
+++ b/runtime/engine/engine_settings_test.cc
@@ -959,6 +959,16 @@ TEST(SessionConfigTest, SetAndGetScopedLoraFile) {
   EXPECT_EQ(session_config.GetScopedLoraFile(), nullptr);
 }
 
+TEST(SessionConfigTest, SetAndGetLoraPath) {
+  SessionConfig session_config = SessionConfig::CreateDefault();
+  EXPECT_FALSE(session_config.GetLoraPath().has_value());
+  session_config.SetLoraPath("lora_model.tflite");
+  ASSERT_TRUE(session_config.GetLoraPath().has_value());
+  EXPECT_EQ(*session_config.GetLoraPath(), "lora_model.tflite");
+  session_config.SetLoraPath(std::nullopt);
+  EXPECT_FALSE(session_config.GetLoraPath().has_value());
+}
+
 TEST(SessionConfigTest, SetAndGetAudioScopedLoraFile) {
   SessionConfig session_config = SessionConfig::CreateDefault();
   EXPECT_EQ(session_config.GetAudioScopedLoraFile(), nullptr);
@@ -976,6 +986,16 @@ TEST(SessionConfigTest, SetAndGetAudioScopedLoraFile) {
   EXPECT_EQ(session_config.GetAudioScopedLoraFile(), file_ptr);
   session_config.SetAudioScopedLoraFile(nullptr);
   EXPECT_EQ(session_config.GetAudioScopedLoraFile(), nullptr);
+}
+
+TEST(SessionConfigTest, SetAndGetAudioLoraPath) {
+  SessionConfig session_config = SessionConfig::CreateDefault();
+  EXPECT_FALSE(session_config.GetAudioLoraPath().has_value());
+  session_config.SetAudioLoraPath("audio_lora_model.tflite");
+  ASSERT_TRUE(session_config.GetAudioLoraPath().has_value());
+  EXPECT_EQ(*session_config.GetAudioLoraPath(), "audio_lora_model.tflite");
+  session_config.SetAudioLoraPath(std::nullopt);
+  EXPECT_FALSE(session_config.GetAudioLoraPath().has_value());
 }
 
 TEST(SessionConfigTest, MaybeUpdateAndValidate) {

--- a/runtime/executor/BUILD
+++ b/runtime/executor/BUILD
@@ -280,6 +280,7 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@litert//litert/cc:litert_model_types",
         "@litert//litert/cc:litert_tensor_buffer_types",
+        "//runtime/components:lora_manager",
         "//runtime/components:model_resources",
         "//runtime/components:model_resources_litert_lm",
         "//runtime/components:model_resources_task",

--- a/runtime/executor/llm_executor_base.h
+++ b/runtime/executor/llm_executor_base.h
@@ -32,6 +32,8 @@
 
 namespace litert::lm {
 
+class ModelAssets;
+
 // The LLM Executor serves as a lightweight and portable wrapper around various
 // converted LLM model formats, i.e. LiteRT. It aims to provide a general,
 // minimal-dependency interface for the users, abstracting the complexities of
@@ -188,6 +190,23 @@ class LlmExecutorBase {
     return absl::UnimplementedError(absl::StrCat(
         "Reset not implemented for backend: ", ExecutorBackendName()));
   };
+
+  // Loads the LoRA model into the executor without activating it.
+  virtual absl::Status LoadLoRA(uint32_t lora_id,
+                                const ModelAssets& model_assets) {
+    return absl::UnimplementedError(absl::StrCat(
+        "LoadLoRA not implemented for backend: ", ExecutorBackendName()));
+  }
+
+  // Sets the current LoRA ID to use. Passing std::nullopt clears the active
+  // LoRA selection for executors that support LoRA.
+  virtual absl::Status UseLoRA(std::optional<uint32_t> lora_id) {
+    if (!lora_id.has_value()) {
+      return absl::OkStatus();
+    }
+    return absl::UnimplementedError(absl::StrCat(
+        "UseLoRA not implemented for backend: ", ExecutorBackendName()));
+  }
 
   // ------------State/context management APIs------------:
   // Creates a new context with the given configs.

--- a/runtime/executor/llm_litert_compiled_model_executor.cc
+++ b/runtime/executor/llm_litert_compiled_model_executor.cc
@@ -49,6 +49,7 @@
 #include "litert/cc/litert_tensor_buffer.h"  // from @litert
 #include "litert/cc/litert_tensor_buffer_types.h"  // from @litert
 #include "runtime/components/embedding_lookup/embedding_lookup_manager.h"
+#include "runtime/components/lora_manager.h"
 #include "runtime/components/model_resources.h"
 #include "runtime/components/sampler_factory.h"
 #include "runtime/executor/common_utils.h"
@@ -921,6 +922,7 @@ absl::Status LlmLiteRtCompiledModelExecutorBase::BindTensorsAndRunDecode(
     LITERT_ASSIGN_OR_RETURN(auto input_buffer_dup, input_buffer.Duplicate());
     decode_input_buffers[input_name] = std::move(input_buffer_dup);
   }
+  RETURN_IF_ERROR(AppendActiveLoraInputBuffers(decode_input_buffers));
   absl::flat_hash_map<absl::string_view, TensorBuffer> decode_output_buffers;
   for (const auto& [output_name, output_buffer] : decode_output_buffers_) {
     // LITERT_ASSIGN_OR_RETURN() causes a compilation error on windows.
@@ -945,6 +947,22 @@ absl::Status LlmLiteRtCompiledModelExecutorBase::BindTensorsAndRunDecode(
 
   if (!gpu_optimized_single_buffer_cache_) {
     std::swap(input_kv_cache_buffers_, output_kv_cache_buffers_);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status LlmLiteRtCompiledModelExecutorBase::AppendActiveLoraInputBuffers(
+    absl::flat_hash_map<absl::string_view, TensorBuffer>& input_buffers) {
+  if (!active_lora_id_.has_value()) {
+    return absl::OkStatus();
+  }
+  if (lora_manager_ == nullptr) {
+    return absl::FailedPreconditionError(
+        "LoRA manager is not initialized. Please load LoRA first.");
+  }
+  ASSIGN_OR_RETURN(auto lora_buffers, lora_manager_->GetLoRABuffers());
+  for (auto& [name, buffer] : lora_buffers) {
+    input_buffers[name] = std::move(buffer);
   }
   return absl::OkStatus();
 }
@@ -1263,6 +1281,31 @@ absl::Status LlmLiteRtCompiledModelExecutorBase::RestoreKVCacheBuffers(
   return absl::OkStatus();
 }
 
+absl::Status LlmLiteRtCompiledModelExecutorBase::LoadLoRA(
+    uint32_t lora_id, const ModelAssets& model_assets) {
+  if (lora_manager_ == nullptr) {
+    ASSIGN_OR_RETURN(
+        lora_manager_,
+        LoraManager::Create(*compiled_model_, kDecodeSignatureRunner));
+  }
+  return lora_manager_->LoadLoRA(lora_id, model_assets);
+}
+
+absl::Status LlmLiteRtCompiledModelExecutorBase::UseLoRA(
+    std::optional<uint32_t> lora_id) {
+  if (!lora_id.has_value()) {
+    active_lora_id_ = std::nullopt;
+    return absl::OkStatus();
+  }
+  if (lora_manager_ == nullptr) {
+    return absl::FailedPreconditionError(
+        "LoRA manager is not initialized. Please load LoRA first.");
+  }
+  RETURN_IF_ERROR(lora_manager_->UseLoRA(*lora_id));
+  active_lora_id_ = lora_id;
+  return absl::OkStatus();
+}
+
 absl::StatusOr<std::unique_ptr<LlmContext>>
 LlmLiteRtCompiledModelExecutorBase::CreateNewContext(
     std::optional<uint32_t> lora_id, RuntimeConfig runtime_config) const {
@@ -1286,7 +1329,7 @@ LlmLiteRtCompiledModelExecutorBase::CreateNewContext(
 
 absl::StatusOr<std::unique_ptr<LlmContext>>
 LlmLiteRtCompiledModelExecutorBase::CloneContext() const {
-  std::optional<uint32_t> lora_id;
+  std::optional<uint32_t> lora_id = llm_context_->processed_context().lora_id();
   ASSIGN_OR_RETURN(auto kv_cache_buffers, CloneKVCacheBuffers());
   ProcessedTokens new_processed_tokens =
       llm_context_->processed_context().processed_tokens();
@@ -1305,6 +1348,7 @@ LlmLiteRtCompiledModelExecutorBase::CloneContext() const {
 absl::Status LlmLiteRtCompiledModelExecutorBase::RestoreContext(
     std::unique_ptr<LlmContext> context_data) {
   llm_context_ = std::move(context_data);
+  RETURN_IF_ERROR(UseLoRA(llm_context_->processed_context().lora_id()));
 
   // We can keep our kv cache buffers if this is the first step. This lets us
   // restore from LlmContexts at step 0 with an empty kv cache.

--- a/runtime/executor/llm_litert_compiled_model_executor.h
+++ b/runtime/executor/llm_litert_compiled_model_executor.h
@@ -35,6 +35,7 @@
 #include "litert/cc/litert_options.h"  // from @litert
 #include "litert/cc/litert_tensor_buffer.h"  // from @litert
 #include "runtime/components/embedding_lookup/embedding_lookup_manager.h"
+#include "runtime/components/lora_manager.h"
 #include "runtime/components/model_resources.h"
 #include "runtime/components/sampler.h"
 #include "runtime/executor/executor_settings_base.h"
@@ -150,6 +151,11 @@ class LlmLiteRtCompiledModelExecutorBase : public LlmExecutor {
 
   // Resets all of the internal states.
   absl::Status Reset() override;
+
+  absl::Status LoadLoRA(uint32_t lora_id,
+                        const ModelAssets& model_assets) override;
+
+  absl::Status UseLoRA(std::optional<uint32_t> lora_id) override;
 
   absl::StatusOr<int> GetVocabSize() override;
 
@@ -269,6 +275,8 @@ class LlmLiteRtCompiledModelExecutorBase : public LlmExecutor {
   // Helper function of DecodeInternal to bind input/output tensors for decode
   // and run decode signature.
   absl::Status BindTensorsAndRunDecode(TensorBuffer* output_logits);
+  absl::Status AppendActiveLoraInputBuffers(
+      absl::flat_hash_map<absl::string_view, TensorBuffer>& input_buffers);
   // Static version of BindTensorsAndRunDecode to be used as a callback for
   // sampler.
   static int BindTensorsAndRunDecodeStatic(void* arg);
@@ -321,6 +329,8 @@ class LlmLiteRtCompiledModelExecutorBase : public LlmExecutor {
   Environment& env_;
   const Model& model_;
   std::unique_ptr<CompiledModel> compiled_model_;
+  std::unique_ptr<LoraManager> lora_manager_;
+  std::optional<uint32_t> active_lora_id_;
 
   absl::flat_hash_map<absl::string_view, TensorBuffer> decode_input_buffers_;
   absl::flat_hash_map<absl::string_view, TensorBuffer> decode_output_buffers_;

--- a/runtime/framework/resource_management/BUILD
+++ b/runtime/framework/resource_management/BUILD
@@ -192,6 +192,7 @@ RESOURCE_MANAGER_DEPS = [
     "@com_google_absl//absl/base:core_headers",
     "@com_google_absl//absl/base:nullability",
     "@com_google_absl//absl/container:flat_hash_map",
+    "@com_google_absl//absl/container:flat_hash_set",
     "@com_google_absl//absl/log:absl_log",
     "@com_google_absl//absl/status",
     "@com_google_absl//absl/status:statusor",
@@ -238,4 +239,42 @@ cc_library(
                    "@litert//litert/cc:litert_tensor_buffer",
                ],
            }),
+)
+
+cc_test(
+    name = "resource_manager_test",
+    srcs = ["resource_manager_test.cc"],
+    data = ["//runtime/testdata"],
+    deps = [
+        ":resource_manager",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "@litert//litert/cc:litert_tensor_buffer",
+        "@litert//litert/test:matchers",
+        "//runtime/components:model_resources",
+        "//runtime/components:model_resources_litert_lm",
+        "//runtime/engine:engine_settings",
+        "//runtime/executor:executor_settings_base",
+        "//runtime/executor:llm_executor",
+        "//runtime/executor:llm_executor_io_types",
+        "//runtime/executor:llm_executor_settings",
+        "//runtime/executor:llm_litert_compiled_model_executor_factory",
+        "//runtime/executor:llm_processed_context",
+        "//runtime/util:convert_tensor_buffer",
+        "//runtime/util:litert_lm_loader",
+        "//runtime/util:scoped_file",
+        "//runtime/util:test_utils",
+    ] + select({
+        "@litert//litert:litert_link_capi_so": [
+            "@litert//litert/cc:litert_api_with_dynamic_runtime",
+        ],
+        "//conditions:default": [
+            "@litert//litert/cc:litert_environment",
+        ],
+    }),
 )

--- a/runtime/framework/resource_management/resource_manager.cc
+++ b/runtime/framework/resource_management/resource_manager.cc
@@ -23,6 +23,7 @@
 
 #include "absl/base/nullability.h"  // from @com_google_absl
 #include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
 #include "absl/log/absl_log.h"  // from @com_google_absl
 #include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
@@ -417,6 +418,15 @@ class LockedLlmExecutor : public LlmExecutor {
 
   absl::Status Reset() override { return llm_executor_->Reset(); }
 
+  absl::Status LoadLoRA(uint32_t lora_id,
+                        const ModelAssets& model_assets) override {
+    return llm_executor_->LoadLoRA(lora_id, model_assets);
+  }
+
+  absl::Status UseLoRA(std::optional<uint32_t> lora_id) override {
+    return llm_executor_->UseLoRA(lora_id);
+  }
+
   absl::StatusOr<int> GetVocabSize() override {
     return llm_executor_->GetVocabSize();
   }
@@ -502,6 +512,7 @@ ResourceManager::ResourceManager(
 
 std::optional<uint32_t> ResourceManager::AssignLoraId(
     std::string lora_path, bool has_scoped_lora_file) {
+  absl::MutexLock lora_lock(&lora_mutex_);
   if (lora_path.empty() && !has_scoped_lora_file) {
     return std::nullopt;
   }
@@ -550,46 +561,68 @@ absl::Status ResourceManager::MaybeCreateLitertEnv() {
 
 absl::StatusOr<std::unique_ptr<ContextHandler>>
 ResourceManager::CreateContextHandler(const SessionConfig& session_config) {
-  // TODO: b/462499294 -
-  //   1. Check if lora is loaded or not.
-  //   2. Get the lora id.
-  //   3. If lora is not loaded, load the lora.
-
-  // Check if the lora is already loaded.
-  // TODO: b/462499294 - Use the real lora path.
-  bool lora_is_loaded =
-      lora_hash_to_id_.find("fake_lora_path") != lora_hash_to_id_.end();
-
   // Find the lora id. If lora_id is not nullopt, it means the lora is used.
+  const std::string lora_path = session_config.GetLoraPath().value_or("");
   std::optional<uint32_t> lora_id = AssignLoraId(
-      /*lora_path=*/"",
+      /*lora_path=*/lora_path,
       /*has_scoped_lora_file=*/session_config.GetScopedLoraFile() != nullptr);
 
   // If lora is used and not loaded, load the lora.
-  if (lora_id.has_value() && !lora_is_loaded) {
-    RET_CHECK(session_config.GetScopedLoraFile() != nullptr);
-    ASSIGN_OR_RETURN(ModelAssets model_assets,
-                     ModelAssets::Create(session_config.GetScopedLoraFile(),
-                                         /*model_path=*/""));
-    return absl::InvalidArgumentError("Lora is not supported.");
+  bool should_load_lora = false;
+  if (lora_id.has_value()) {
+    absl::MutexLock lora_lock(&lora_mutex_);
+    should_load_lora = !loaded_lora_ids_.contains(*lora_id);
+  }
+  if (should_load_lora) {
+    absl::StatusOr<ModelAssets> model_assets =
+        session_config.GetScopedLoraFile() != nullptr
+            ? ModelAssets::Create(session_config.GetScopedLoraFile(), lora_path)
+            : ModelAssets::Create(lora_path);
+    ASSIGN_OR_RETURN(ModelAssets lora_model_assets, std::move(model_assets));
+
+    MovableMutexLock lock(&executor_mutex_);
+    absl::MutexLock lora_lock(&lora_mutex_);
+    if (!loaded_lora_ids_.contains(*lora_id)) {
+      RETURN_IF_ERROR(llm_executor_->LoadLoRA(*lora_id, lora_model_assets));
+      loaded_lora_ids_.insert(*lora_id);
+    }
   }
 
   // Find the audio lora id.
+  const std::string audio_lora_path =
+      session_config.GetAudioLoraPath().value_or("");
   std::optional<uint32_t> audio_lora_id = AssignLoraId(
-      /*lora_path=*/"",
+      /*lora_path=*/audio_lora_path,
       /*has_scoped_lora_file=*/session_config.GetAudioScopedLoraFile() !=
           nullptr);
   if (audio_lora_id.has_value()) {
-    RET_CHECK(session_config.GetAudioScopedLoraFile() != nullptr);
-    ASSIGN_OR_RETURN(
-        ModelAssets lora_model_assets,
-        ModelAssets::Create(session_config.GetAudioScopedLoraFile(),
-                            /*model_path=*/""));
+    bool should_load_audio_lora = false;
+    {
+      absl::MutexLock lora_lock(&lora_mutex_);
+      should_load_audio_lora =
+          !loaded_audio_lora_ids_.contains(*audio_lora_id);
+    }
+    std::optional<ModelAssets> audio_lora_model_assets;
+    if (should_load_audio_lora) {
+      absl::StatusOr<ModelAssets> model_assets =
+          session_config.GetAudioScopedLoraFile() != nullptr
+              ? ModelAssets::Create(session_config.GetAudioScopedLoraFile(),
+                                    audio_lora_path)
+              : ModelAssets::Create(audio_lora_path);
+      ASSIGN_OR_RETURN(audio_lora_model_assets, std::move(model_assets));
+    }
+
     RETURN_IF_ERROR(TryLoadingAudioExecutor());
     ASSIGN_OR_RETURN(auto audio_executor, AcquireAudioExecutor());
-    RETURN_IF_ERROR(
-        audio_executor->LoadLoRA(audio_lora_id.value(), lora_model_assets));
-    RETURN_IF_ERROR(audio_executor->UseLoRA(audio_lora_id.value()));
+    if (audio_lora_model_assets.has_value()) {
+      absl::MutexLock lora_lock(&lora_mutex_);
+      if (!loaded_audio_lora_ids_.contains(*audio_lora_id)) {
+        RETURN_IF_ERROR(
+            audio_executor->LoadLoRA(*audio_lora_id, *audio_lora_model_assets));
+        loaded_audio_lora_ids_.insert(*audio_lora_id);
+      }
+    }
+    RETURN_IF_ERROR(audio_executor->UseLoRA(*audio_lora_id));
   }
 
   auto runtime_config = RuntimeConfig{

--- a/runtime/framework/resource_management/resource_manager.h
+++ b/runtime/framework/resource_management/resource_manager.h
@@ -24,6 +24,7 @@
 #include "absl/base/nullability.h"  // from @com_google_absl
 #include "absl/base/thread_annotations.h"  // from @com_google_absl
 #include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
 #include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
 #include "absl/synchronization/mutex.h"  // from @com_google_absl
@@ -84,7 +85,8 @@ class ResourceManager {
   // assign a unique, custom lora_path. This lora_path serves as the identifier
   // for the LoRA across all sessions referencing that scoped file.
   std::optional<uint32_t> AssignLoraId(std::string lora_path,
-                                       bool has_scoped_lora_file);
+                                       bool has_scoped_lora_file)
+      ABSL_LOCKS_EXCLUDED(lora_mutex_);
 
   // Creates a new context handler from the provided session config struct.
   // If a session specific lora is provided, the lora will be loaded and the
@@ -159,9 +161,21 @@ class ResourceManager {
   std::shared_ptr<ContextHandler> current_handler_
       ABSL_GUARDED_BY(executor_mutex_);
 
+  // Guards LoRA id assignment and loaded-LoRA bookkeeping.
+  absl::Mutex lora_mutex_;
+
   // Map lora id from hash. If lora is provided by lora path, lora path will be
   // treated as the hash key.
-  absl::flat_hash_map<std::string, uint32_t> lora_hash_to_id_;
+  absl::flat_hash_map<std::string, uint32_t> lora_hash_to_id_
+      ABSL_GUARDED_BY(lora_mutex_);
+
+  // Tracks LoRA ids already loaded into the text executor.
+  absl::flat_hash_set<uint32_t> loaded_lora_ids_
+      ABSL_GUARDED_BY(lora_mutex_);
+
+  // Tracks LoRA ids already loaded into the audio executor.
+  absl::flat_hash_set<uint32_t> loaded_audio_lora_ids_
+      ABSL_GUARDED_BY(lora_mutex_);
 
   // The mutex lock for the vision executor.
   absl::Mutex vision_executor_mutex_;

--- a/runtime/framework/resource_management/resource_manager_test.cc
+++ b/runtime/framework/resource_management/resource_manager_test.cc
@@ -1,0 +1,292 @@
+// Copyright 2026 The ODML Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/framework/resource_management/resource_manager.h"
+
+#include <cstdint>
+#include <filesystem>  // NOLINT: Required for testdata path manipulation.
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_environment.h"  // from @litert
+#include "litert/cc/litert_tensor_buffer.h"  // from @litert
+#include "litert/test/matchers.h"  // from @litert
+#include "runtime/components/model_resources.h"
+#include "runtime/components/model_resources_litert_lm.h"
+#include "runtime/engine/engine_settings.h"
+#include "runtime/executor/executor_settings_base.h"
+#include "runtime/executor/llm_executor.h"
+#include "runtime/executor/llm_executor_io_types.h"
+#include "runtime/executor/llm_executor_settings.h"
+#include "runtime/executor/llm_litert_compiled_model_executor_factory.h"
+#include "runtime/executor/llm_processed_context.h"
+#include "runtime/util/convert_tensor_buffer.h"
+#include "runtime/util/litert_lm_loader.h"
+#include "runtime/util/scoped_file.h"
+#include "runtime/util/test_utils.h"  // IWYU pragma: keep
+
+namespace litert::lm {
+namespace {
+
+constexpr char kTestLoraModelPath[] =
+    "litert_lm/runtime/testdata/test_lm_lora.litertlm";
+constexpr char kTestLoraWeightsPath[] =
+    "litert_lm/runtime/testdata/test_lora_rank32_f16_all_ones.tflite";
+constexpr int kMaxNumTokens = 32;
+
+std::string TestDataPath(absl::string_view relative_path) {
+  return (std::filesystem::path(::testing::SrcDir()) / relative_path).string();
+}
+
+absl::StatusOr<std::unique_ptr<ModelResources>>
+CreateLitertLmModelResources(absl::string_view model_path) {
+  ASSIGN_OR_RETURN(auto scoped_file, ScopedFile::Open(model_path));
+  ASSIGN_OR_RETURN(auto loader, LitertLmLoader::Create(std::move(scoped_file)));
+  return ModelResourcesLitertLm::Create(std::move(loader));
+}
+
+class RecordingLlmExecutor : public LlmExecutor {
+ public:
+  absl::Status Prefill(const ExecutorInputs& inputs) override {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::vector<std::vector<int>>> Decode() override {
+    return std::vector<std::vector<int>>();
+  }
+
+  absl::string_view ExecutorBackendName() const override {
+    return "RecordingLlmExecutor";
+  }
+
+  absl::Status LoadLoRA(uint32_t lora_id,
+                        const ModelAssets& model_assets) override {
+    loaded_lora_ids_.push_back(lora_id);
+    auto path = model_assets.GetPath();
+    loaded_lora_paths_.push_back(path.ok() ? std::string(*path) : "");
+    return absl::OkStatus();
+  }
+
+  absl::Status UseLoRA(std::optional<uint32_t> lora_id) override {
+    used_lora_ids_.push_back(lora_id);
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::unique_ptr<LlmContext>> CreateNewContext(
+      std::optional<uint32_t> lora_id,
+      RuntimeConfig runtime_config) const override {
+    created_lora_ids_.push_back(lora_id);
+    auto processed_context = std::make_unique<LlmProcessedContext>(
+        lora_id, absl::flat_hash_map<absl::string_view, TensorBuffer>());
+    return std::make_unique<LlmContext>(
+        std::move(processed_context),
+        std::make_unique<RuntimeConfig>(std::move(runtime_config)),
+        std::make_unique<RuntimeState>());
+  }
+
+  absl::Status RestoreContext(
+      std::unique_ptr<LlmContext> context_data) override {
+    return UseLoRA(context_data->processed_context().lora_id());
+  }
+
+  const std::vector<uint32_t>& loaded_lora_ids() const {
+    return loaded_lora_ids_;
+  }
+
+  const std::vector<std::string>& loaded_lora_paths() const {
+    return loaded_lora_paths_;
+  }
+
+  const std::vector<std::optional<uint32_t>>& used_lora_ids() const {
+    return used_lora_ids_;
+  }
+
+  const std::vector<std::optional<uint32_t>>& created_lora_ids() const {
+    return created_lora_ids_;
+  }
+
+ private:
+  std::vector<uint32_t> loaded_lora_ids_;
+  std::vector<std::string> loaded_lora_paths_;
+  std::vector<std::optional<uint32_t>> used_lora_ids_;
+  mutable std::vector<std::optional<uint32_t>> created_lora_ids_;
+};
+
+std::string CreateTempLoraFile(absl::string_view filename) {
+  const std::string lora_path =
+      absl::StrCat(::testing::TempDir(), "/", filename);
+  std::ofstream ofs(lora_path);
+  ofs << "lora";
+  return lora_path;
+}
+
+absl::Status SetScopedLoraFile(SessionConfig& session_config,
+                               absl::string_view lora_path) {
+  auto scoped_file = ScopedFile::Open(lora_path);
+  if (!scoped_file.ok()) {
+    return scoped_file.status();
+  }
+  session_config.SetScopedLoraFile(
+      std::make_shared<ScopedFile>(std::move(*scoped_file)));
+  return absl::OkStatus();
+}
+
+void ConfigureGreedySampler(SessionConfig& session_config) {
+  proto::SamplerParameters& sampler_params =
+      session_config.GetMutableSamplerParams();
+  sampler_params.set_type(proto::SamplerParameters::TOP_P);
+  sampler_params.set_k(1);
+  sampler_params.set_p(0.0f);
+  sampler_params.set_temperature(1.0f);
+  sampler_params.set_seed(0);
+}
+
+TEST(ResourceManagerTest, CreateContextHandlerLoadsTextLora) {
+  auto executor = std::make_unique<RecordingLlmExecutor>();
+  RecordingLlmExecutor* executor_ptr = executor.get();
+  ASSERT_OK_AND_ASSIGN(auto model_assets, ModelAssets::Create("base_model"));
+  ASSERT_OK_AND_ASSIGN(
+      auto executor_settings,
+      LlmExecutorSettings::CreateDefault(model_assets, Backend::CPU));
+  ResourceManager resource_manager(
+      /*model_resources=*/nullptr, std::move(executor),
+      /*vision_executor_settings=*/nullptr,
+      /*audio_executor_settings=*/nullptr, std::move(executor_settings),
+      /*litert_env=*/nullptr);
+
+  const std::string lora_path = CreateTempLoraFile("text_lora.tflite");
+  SessionConfig session_config = SessionConfig::CreateDefault();
+  session_config.SetLoraPath(lora_path);
+  ASSERT_OK(SetScopedLoraFile(session_config, lora_path));
+
+  ASSERT_OK_AND_ASSIGN(auto context_handler,
+                       resource_manager.CreateContextHandler(session_config));
+
+  ASSERT_EQ(executor_ptr->loaded_lora_ids().size(), 1);
+  EXPECT_EQ(executor_ptr->loaded_lora_ids()[0], 0);
+  ASSERT_EQ(executor_ptr->loaded_lora_paths().size(), 1);
+  EXPECT_EQ(executor_ptr->loaded_lora_paths()[0], lora_path);
+  EXPECT_TRUE(executor_ptr->used_lora_ids().empty());
+  ASSERT_EQ(executor_ptr->created_lora_ids().size(), 1);
+  ASSERT_TRUE(executor_ptr->created_lora_ids()[0].has_value());
+  EXPECT_EQ(*executor_ptr->created_lora_ids()[0], 0);
+
+  auto shared_context_handler =
+      std::shared_ptr<ContextHandler>(std::move(context_handler));
+  ASSERT_OK_AND_ASSIGN(auto locked_executor,
+                       resource_manager.AcquireExecutorWithContextHandler(
+                           shared_context_handler));
+  ASSERT_EQ(executor_ptr->used_lora_ids().size(), 1);
+  ASSERT_TRUE(executor_ptr->used_lora_ids()[0].has_value());
+  EXPECT_EQ(*executor_ptr->used_lora_ids()[0], 0);
+}
+
+TEST(ResourceManagerTest, CreateContextHandlerDoesNotReloadSameTextLoraPath) {
+  auto executor = std::make_unique<RecordingLlmExecutor>();
+  RecordingLlmExecutor* executor_ptr = executor.get();
+  ASSERT_OK_AND_ASSIGN(auto model_assets, ModelAssets::Create("base_model"));
+  ASSERT_OK_AND_ASSIGN(
+      auto executor_settings,
+      LlmExecutorSettings::CreateDefault(model_assets, Backend::CPU));
+  ResourceManager resource_manager(
+      /*model_resources=*/nullptr, std::move(executor),
+      /*vision_executor_settings=*/nullptr,
+      /*audio_executor_settings=*/nullptr, std::move(executor_settings),
+      /*litert_env=*/nullptr);
+
+  const std::string lora_path = CreateTempLoraFile("shared_text_lora.tflite");
+  SessionConfig session_config = SessionConfig::CreateDefault();
+  session_config.SetLoraPath(lora_path);
+  ASSERT_OK(SetScopedLoraFile(session_config, lora_path));
+
+  ASSERT_OK_AND_ASSIGN(auto first_context_handler,
+                       resource_manager.CreateContextHandler(session_config));
+  ASSERT_OK_AND_ASSIGN(auto second_context_handler,
+                       resource_manager.CreateContextHandler(session_config));
+
+  ASSERT_EQ(executor_ptr->loaded_lora_ids().size(), 1);
+  EXPECT_EQ(executor_ptr->loaded_lora_ids()[0], 0);
+  ASSERT_EQ(executor_ptr->created_lora_ids().size(), 2);
+  ASSERT_TRUE(executor_ptr->created_lora_ids()[0].has_value());
+  ASSERT_TRUE(executor_ptr->created_lora_ids()[1].has_value());
+  EXPECT_EQ(*executor_ptr->created_lora_ids()[0], 0);
+  EXPECT_EQ(*executor_ptr->created_lora_ids()[1], 0);
+}
+
+TEST(ResourceManagerE2eTest, LoadsAndRunsTextLoraWithRealExecutor) {
+  const std::string model_path = TestDataPath(kTestLoraModelPath);
+  const std::string lora_path = TestDataPath(kTestLoraWeightsPath);
+
+  ASSERT_OK_AND_ASSIGN(auto model_resources,
+                       CreateLitertLmModelResources(model_path));
+  ASSERT_OK_AND_ASSIGN(auto model_assets, ModelAssets::Create(model_path));
+  ASSERT_OK_AND_ASSIGN(
+      auto executor_settings,
+      LlmExecutorSettings::CreateDefault(model_assets, Backend::CPU));
+  executor_settings.SetCacheDir(":nocache");
+  executor_settings.SetMaxNumTokens(kMaxNumTokens);
+
+  LITERT_ASSERT_OK_AND_ASSIGN(
+      auto env, litert::Environment::Create(std::vector<Environment::Option>()));
+  ASSERT_OK_AND_ASSIGN(auto executor,
+                       CreateLlmLiteRtCompiledModelExecutor(
+                           executor_settings, env, *model_resources));
+  ResourceManager resource_manager(
+      model_resources.get(), std::move(executor),
+      /*vision_executor_settings=*/nullptr,
+      /*audio_executor_settings=*/nullptr, std::move(executor_settings), &env);
+
+  SessionConfig session_config = SessionConfig::CreateDefault();
+  session_config.SetLoraPath(lora_path);
+  ConfigureGreedySampler(session_config);
+  ASSERT_OK(SetScopedLoraFile(session_config, lora_path));
+  ASSERT_OK_AND_ASSIGN(auto unique_context_handler,
+                       resource_manager.CreateContextHandler(session_config));
+  auto context_handler =
+      std::shared_ptr<ContextHandler>(std::move(unique_context_handler));
+
+  ASSERT_OK_AND_ASSIGN(auto locked_executor,
+                       resource_manager.AcquireExecutorWithContextHandler(
+                           context_handler));
+
+  ExecutorInputs inputs;
+  const std::vector<int> input_tokens = {1, 2, 0};
+  LITERT_ASSERT_OK_AND_ASSIGN(
+      auto input_tokens_buffer,
+      CopyToTensorBuffer<int>(absl::MakeSpan(input_tokens), {1, 3}));
+  inputs.SetTextData(ExecutorTextData(std::move(input_tokens_buffer)));
+
+  ASSERT_OK(locked_executor->Prefill(inputs));
+  ASSERT_OK_AND_ASSIGN(auto current_step, locked_executor->GetCurrentStep());
+  EXPECT_EQ(current_step, input_tokens.size());
+
+  ASSERT_OK_AND_ASSIGN(auto output_tokens, locked_executor->Decode());
+  EXPECT_FALSE(output_tokens.empty());
+  ASSERT_OK_AND_ASSIGN(current_step, locked_executor->GetCurrentStep());
+  EXPECT_EQ(current_step, input_tokens.size() + 1);
+}
+
+}  // namespace
+}  // namespace litert::lm


### PR DESCRIPTION
## Summary

- Store text and audio LoRA paths in `SessionConfig` when callers set LoRA files through the C API path setters.
- Route text LoRA through `ResourceManager`: assign stable IDs by path, load each adapter once, and create text contexts with the selected LoRA ID.
- Add `LoadLoRA` / `UseLoRA` support to the LiteRT compiled-model LLM executor, inject active LoRA input buffers during decode, and preserve the active LoRA ID across context clone/restore.
- Add ResourceManager tests for load/reuse/activation behavior plus a real LiteRT-LM model + LoRA adapter smoke that runs `CreateContextHandler -> AcquireExecutorWithContextHandler -> Prefill -> Decode`.

## Context

Related to #1188. This PR is intentionally narrow: it wires the existing LoRA runtime pieces into the session/resource-manager path so text LoRA adapters can be used from session configuration instead of failing with `Lora is not supported.`

`CONTRIBUTING.md` currently says the repository is not broadly ready for external code contributions, but I am marking this ready for review because the change is scoped to the LoRA session path discussed in #1188 and includes local validation.

## Validation

- `git diff --check`
- `/tmp/bazel-7.6.1-darwin-arm64 test //runtime/framework/resource_management:resource_manager_test --test_output=errors --cache_test_results=no`
- `/tmp/bazel-7.6.1-darwin-arm64 test //runtime/engine:engine_settings_test //runtime/framework/resource_management:resource_manager_test //runtime/components:lora_manager_test //runtime/components:lora_test --test_output=errors`
- `/tmp/bazel-7.6.1-darwin-arm64 build //runtime/executor:llm_litert_compiled_model_executor //runtime/framework/resource_management:resource_manager //c:engine_cpu`
- `/tmp/bazel-7.6.1-darwin-arm64 test //c:engine_test --test_output=errors`

## Local setup note

The C test target needs the macOS prebuilts from Git LFS. Before installing Git LFS and running `git lfs pull --include="prebuilt/macos_arm64/*" --exclude=""`, my checkout had 132-byte LFS pointer files under `prebuilt/macos_arm64`, which made the linker reject `libGemmaModelConstraintProvider.dylib` as an unknown file type. After pulling the LFS objects, `//c:engine_test` passed.

## Scope and limitations

- Validated locally on macOS/CPU with the checked-in LiteRT-LM LoRA test fixture.
- Android/device validation is not included in this PR.
- Audio LoRA path storage/reuse bookkeeping is kept consistent with the existing audio code path, but this PR's real E2E coverage is for text LoRA.