### PR TITLE
Enable sampler-handled decode input for models with in-graph embeddings

### DIFF
--- a/runtime/executor/llm_litert_compiled_model_executor.cc
+++ b/runtime/executor/llm_litert_compiled_model_executor.cc
@@ -1369,15 +1369,17 @@ absl::Status LlmLiteRtCompiledModelExecutorBase::InitializeSampler(
       CreateSampler(sampler_backend, output_heads, std::move(sampler_params),
                     env_.Get(), /*sequence_size=*/1, vocab_size, data_type));
 
-  // Disable GPU token copy for models that run embedding on the GPU.
-  const bool runs_embedding_on_gpu = (embedding_lookup_ == nullptr);
-
   // If the sampler can handle input, prepare the input tensors for it.
+  // Models whose decode signature takes token ids (embedding computed inside
+  // the graph) are eligible: the sampler writes the sampled id directly into
+  // the decode input buffers, removing the per-token readback/re-encode sync
+  // on the host. Models with an external embedder keep the host loop (their
+  // decode input is embeddings, not token ids). Hosts can opt out via
+  // AdvancedSettings.sampler_handles_input.
   sampler_handles_input_ =
       (!executor_settings_.GetAdvancedSettings().has_value() ||
        executor_settings_.GetAdvancedSettings()->sampler_handles_input) &&
-      sampler_->CanHandleInput() && !signatures_.input_tokens.empty() &&
-      !runs_embedding_on_gpu;
+      sampler_->CanHandleInput() && !signatures_.input_tokens.empty();
   if (sampler_handles_input_) {
     ABSL_LOG(INFO) << "Sampler will handle decode input tensors.";
     if (!decode_prev_input_pos_) {


### PR DESCRIPTION
## What

`InitializeSampler` currently gates `sampler_handles_input_` on the model having an **external embedder component** (`embedding_lookup_ != nullptr`) in addition to a token-ids decode input. Standard single-file `.litertlm` exports compute the embedding inside the graph, so the sampler-driven token loop (the sampler writes the sampled id directly into the decode input buffers via `SetInputTensorsAndInferenceFunc` and drives the next step) never engages for them.

This PR removes that restriction. Models whose decode signature takes token ids use the sampler-driven loop whenever the sampler reports `CanHandleInput()`. Models with an external embedder are still excluded naturally — their decode input is embeddings, not token ids — and hosts can opt out via `AdvancedSettings.sampler_handles_input`.

## Why

With the host-driven loop, GPU-backend decode pays a fixed ~0.6–0.9 ms/token synchronization cost: a Metal System Trace on macOS shows exactly two GPU-idle bubbles per token (sampled-id readback → host detokenize/stop-check, then next-step re-encode/submit), independent of model size. Because the cost is fixed, the relative penalty grows as models get faster.

## Measurements (Mac Studio M4 Max, WebGPU backend, `litert_lm_main`)

| model | host-driven loop | sampler-driven loop | delta |
|---|--:|--:|--:|
| DeepSeek-R1-Distill-Qwen-1.5B q8 | 116.6 tok/s | 122.4 tok/s | **+5.0%** |
| MiniCPM5-1B int8 (identical 194-token decode) | 204.0 tok/s | 223.3 tok/s | **+9.5%** |

Metal System Trace (DeepSeek q8): GPU busy 93% → **99.5%**, GPU idle 0.66 → **0.04 ms/token**, inter-command-buffer gap p99 871 µs → **1 µs**. Per-kernel times unchanged — the gain is pure loop scheduling. Generated text verified coherent on both models.

## Scope notes

- **OpenCL (Android GPU)**: unaffected — the OpenCL sampler wiring does not provide `CanHandleInput`, so the gate stays closed there.
- **WebGPU**: tested on macOS (numbers above).
- **Metal (iOS)**: the statically linked Metal sampler exposes the full C API, so this path would newly engage there; I could not test on-device iOS with a source build — happy to help validate if useful.
- The measurements were taken with the WebGPU sampler C API fully wired; note that the **macOS prebuilt `libLiteRtTopKWebGpuSampler.dylib` only exports `Create`/`Destroy`/`SampleToIdAndScoreBuffer`**, so the dlopen path cannot construct the sampler in source builds (silent CPU-sampling fallback). I will file that separately — release/static builds are not affected.