### PR TITLE
Fix typo in README.md command example (E2B -> E4B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LiteRT, engineered for **high-performance**, **cross-platform** execution.
 
 ```bash
 litert-lm run  \
-   --from-huggingface-repo=litert-community/gemma-4-E2B-it-litert-lm \
+   --from-huggingface-repo=litert-community/gemma-4-E4B-it-litert-lm \
    gemma-4-E4B-it.litertlm \
    --backend=gpu \
    --enable-speculative-decoding=true \


### PR DESCRIPTION
The example in the README section titled 'Try Gemma4-E4B with MTP...' tries to download the E4B model from the E2B HuggingFace repo, which fails. This PR updates the repository flag to correctly point to the E4B repo.