### PR TITLE
Agent/fix windows nvidia webgpu upload

### DIFF
--- a/PATCH.litert_windows_nvidia_webgpu_upload
+++ b/PATCH.litert_windows_nvidia_webgpu_upload
@@ -1,0 +1,23 @@
+--- a/ml_drift_delegate/delegate/delegate_webgpu.cc
++++ b/ml_drift_delegate/delegate/delegate_webgpu.cc
+@@ -685,6 +685,18 @@ TfLiteDelegatePtr CreateMlDriftWebGpuDelegate(MlDriftDelegateOptionsPtr options,
+ 
+ #if !defined(__EMSCRIPTEN__)
+   // Set up the executors.
++#if defined(_WIN32)
++  // Windows/D3D12 drivers have shown crashes while LiteRT performs concurrent
++  // WebGPU weight uploads during delegate initialization. Keep WebGPU/D3D12
++  // execution enabled, but serialize the one-time weight upload on Windows.
++  //
++  // This is deliberately scoped to Windows and does not disable GPU compute.
++  if (delegate_data->options->num_threads_to_upload > 0) {
++    ABSL_LOG(WARNING)
++        << "Windows WebGPU: disabling asynchronous weight uploads (requested "
++        << delegate_data->options->num_threads_to_upload
++        << " threads); D3D12 GPU execution remains enabled.";
++    delegate_data->options->num_threads_to_upload = 0;
++  }
++#endif  // defined(_WIN32)
+   ABSL_LOG(INFO) << "# of threads to upload weights = "
+                  << delegate_data->options->num_threads_to_upload;
+   if (delegate_data->options->num_threads_to_upload > 0) {

--- a/WINDOWS_NVIDIA_WEBGPU_TEST.md
+++ b/WINDOWS_NVIDIA_WEBGPU_TEST.md
@@ -1,0 +1,124 @@
+# Windows NVIDIA WebGPU / D3D12 validation
+
+This branch is an experimental Windows stability patch for NVIDIA GPUs such as the RTX 3080. It targets a crash pattern seen after Dawn/WebGPU successfully selects an NVIDIA D3D12 adapter and LiteRT begins concurrent model-weight uploads.
+
+## What the patch changes
+
+`PATCH.litert_windows_nvidia_webgpu_upload` patches the LiteRT revision pinned by this LiteRT-LM workspace. On `_WIN32` only, it changes `num_threads_to_upload` to `0` before the WebGPU upload executors are created.
+
+That means:
+
+- D3D12/WebGPU GPU inference remains enabled.
+- NVIDIA adapter selection is not disabled.
+- Only the one-time model weight upload is serialized on Windows.
+- Linux, Android, macOS, iOS, and Web behavior is unchanged.
+
+This is intentionally a narrow A/B mitigation. If it fixes the Windows NVIDIA crash, it gives us a small upstreamable change. If the crash remains, the next experiment should separately investigate Windows host-mapped-pointer use rather than combining unrelated mitigations.
+
+## Prerequisites
+
+Use a native Windows 10/11 x64 development machine with:
+
+1. A current NVIDIA display driver.
+2. Visual Studio 2022 / Build Tools with the MSVC C++ workload.
+3. Git for Windows and Git LFS.
+4. Python 3.13 as required by LiteRT-LM's Windows build guide.
+5. Java with `JAVA_HOME` configured.
+6. Bazelisk (recommended):
+
+```powershell
+winget install --id=Bazel.Bazelisk -e
+```
+
+7. Windows long paths enabled. If needed, use a short Bazel output base such as `C:\bzl`.
+
+## Clone the test branch
+
+```powershell
+git clone -b agent/fix-windows-nvidia-webgpu-upload https://github.com/ornab74/LiteRT-LM.git
+cd LiteRT-LM
+git lfs install
+git lfs pull
+```
+
+## Build the patched Windows GPU bundle
+
+From PowerShell:
+
+```powershell
+.\tools\windows\build_nvidia_webgpu_test.ps1
+```
+
+The helper:
+
+1. Materializes the Windows Git-LFS runtime DLLs.
+2. Checks out the exact LiteRT revision pinned by this LiteRT-LM workspace into a helper-owned temporary directory.
+3. Applies `PATCH.litert_windows_nvidia_webgpu_upload` there.
+4. Builds `//runtime/engine:litert_lm_main` with Windows GPU dynamic-link options.
+5. Builds `@litert//litert/runtime/accelerators/gpu:libLiteRtWebGpuAccelerator` from the patched LiteRT source.
+6. Copies the normal Windows runtime DLLs into the output bundle.
+7. Replaces the bundled `libLiteRtWebGpuAccelerator.dll` with the freshly built patched DLL.
+
+The default output is:
+
+```text
+out/windows-nvidia-webgpu/
+```
+
+## Build and immediately test a model
+
+```powershell
+.\tools\windows\build_nvidia_webgpu_test.ps1 `
+  -ModelPath "C:\models\gemma-4-E2B-it.litertlm" `
+  -Prompt "Reply with exactly: RTX GPU OK"
+```
+
+Or run the resulting executable manually:
+
+```powershell
+cd .\out\windows-nvidia-webgpu
+.\litert_lm_main.exe `
+  --backend=gpu `
+  --model_path="C:\models\gemma-4-E2B-it.litertlm" `
+  --input_prompt="Reply with exactly: RTX GPU OK"
+```
+
+## What counts as a successful RTX 3080 result
+
+The important result is not merely that the executable starts. Capture the full console output and verify all of these:
+
+1. Dawn/WebGPU discovers and selects the NVIDIA / D3D12 adapter.
+2. The log contains:
+
+```text
+Windows WebGPU: disabling asynchronous weight uploads
+```
+
+3. The log then contains:
+
+```text
+# of threads to upload weights = 0
+```
+
+4. Model initialization finishes without the previous access violation / segmentation fault.
+5. Prompt generation completes while `--backend=gpu` is still selected.
+
+For additional confirmation, Windows Task Manager's GPU page can be used to observe the process using the NVIDIA GPU during inference. The console/backend result is the primary test; Task Manager is supplemental.
+
+## Failure interpretation
+
+### NVIDIA adapter is not discovered
+
+That is a different failure from the upload crash. Capture the Dawn adapter enumeration logs, Windows version, NVIDIA driver version, and `nvidia-smi` output. Do not treat this patch as an adapter-discovery fix.
+
+### The warning and `threads = 0` appear, but it still crashes
+
+The asynchronous upload race has been removed and the failure is further downstream. Keep this patch isolated and test the next Windows-only candidate separately (notably native host-mapped-pointer behavior) so an upstream change remains attributable.
+
+### It still says upload threads are greater than zero
+
+The runtime is almost certainly loading an old/prebuilt `libLiteRtWebGpuAccelerator.dll`. Confirm the executable is being run from `out/windows-nvidia-webgpu` and that the freshly built DLL was copied there by the helper.
+
+## Upstream plan
+
+Do not open the Google upstream PR based only on compilation. First reproduce the original RTX 3080 failure, run this patched bundle on the same host/model, and save both logs. If the patched run succeeds, the upstream PR can be kept small and include the before/after Windows NVIDIA evidence plus references to the existing Windows WebGPU crash reports.

--- a/tools/windows/build_nvidia_webgpu_test.ps1
+++ b/tools/windows/build_nvidia_webgpu_test.ps1
@@ -1,0 +1,177 @@
+[CmdletBinding()]
+param(
+  [string]$OutputDir = "out/windows-nvidia-webgpu",
+  [string]$ModelPath = "",
+  [string]$Prompt = "What is the capital of France?"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$LiteRtRef = "b0f6c12088df229f6342f1af164caa66ffa7b010"
+$LiteRtPatch = Join-Path $RepoRoot "PATCH.litert_windows_nvidia_webgpu_upload"
+$OutputRoot = Join-Path $RepoRoot $OutputDir
+$LiteRtRoot = Join-Path ([IO.Path]::GetTempPath()) ("litert-lm-nvidia-" + $LiteRtRef.Substring(0, 12))
+
+function Require-Command([string]$Name) {
+  $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+  if (-not $cmd) {
+    throw "Required command '$Name' was not found in PATH."
+  }
+  return $cmd.Source
+}
+
+function Invoke-Checked([string]$Exe, [string[]]$Args, [string]$WorkingDirectory = $RepoRoot) {
+  Write-Host "> $Exe $($Args -join ' ')" -ForegroundColor Cyan
+  Push-Location $WorkingDirectory
+  try {
+    & $Exe @Args
+    if ($LASTEXITCODE -ne 0) {
+      throw "Command failed with exit code $LASTEXITCODE: $Exe $($Args -join ' ')"
+    }
+  } finally {
+    Pop-Location
+  }
+}
+
+function Resolve-BazelOutput([string]$Bazel, [string[]]$CommonArgs, [string]$Target, [string]$Extension) {
+  Push-Location $RepoRoot
+  try {
+    $lines = & $Bazel cquery @CommonArgs $Target "--output=files"
+    if ($LASTEXITCODE -ne 0) {
+      throw "bazel cquery failed for $Target"
+    }
+  } finally {
+    Pop-Location
+  }
+
+  $candidate = $lines |
+    Where-Object { $_ -and $_.Trim().ToLowerInvariant().EndsWith($Extension.ToLowerInvariant()) } |
+    Select-Object -First 1
+  if (-not $candidate) {
+    throw "Could not resolve a $Extension output for Bazel target $Target. Output: $($lines -join '; ')"
+  }
+
+  if ([IO.Path]::IsPathRooted($candidate)) {
+    return (Resolve-Path $candidate).Path
+  }
+  return (Resolve-Path (Join-Path $RepoRoot $candidate)).Path
+}
+
+function Assert-NotLfsPointer([string]$Path) {
+  if (-not (Test-Path $Path)) {
+    throw "Required runtime file is missing: $Path"
+  }
+  $firstLine = Get-Content $Path -TotalCount 1 -ErrorAction Stop
+  if ($firstLine -eq "version https://git-lfs.github.com/spec/v1") {
+    throw "Git LFS file is still a pointer: $Path. Run 'git lfs install' and 'git lfs pull'."
+  }
+}
+
+$Git = Require-Command "git"
+$BazelCommand = Get-Command "bazelisk" -ErrorAction SilentlyContinue
+if (-not $BazelCommand) {
+  $BazelCommand = Get-Command "bazel" -ErrorAction SilentlyContinue
+}
+if (-not $BazelCommand) {
+  throw "Bazelisk/Bazel was not found. Recommended: winget install --id=Bazel.Bazelisk -e"
+}
+$Bazel = $BazelCommand.Source
+
+if (-not (Test-Path $LiteRtPatch)) {
+  throw "Patch not found: $LiteRtPatch"
+}
+
+Write-Host "=== LiteRT-LM Windows NVIDIA WebGPU test build ===" -ForegroundColor Green
+Write-Host "LiteRT-LM repo : $RepoRoot"
+Write-Host "LiteRT commit   : $LiteRtRef"
+Write-Host "Patched checkout: $LiteRtRoot"
+Write-Host "Output bundle   : $OutputRoot"
+
+# Materialize the Windows runtime assets before packaging the test bundle.
+Invoke-Checked $Git @("lfs", "install", "--local")
+Invoke-Checked $Git @("lfs", "pull", "--include=prebuilt/windows_x86_64/*")
+
+$PrebuiltRoot = Join-Path $RepoRoot "prebuilt\windows_x86_64"
+if (-not (Test-Path $PrebuiltRoot)) {
+  throw "Windows prebuilt directory was not found: $PrebuiltRoot"
+}
+Get-ChildItem $PrebuiltRoot -Filter "*.dll" | ForEach-Object { Assert-NotLfsPointer $_.FullName }
+
+# Prepare an isolated checkout of the exact LiteRT revision pinned by this LiteRT-LM workspace.
+# Destructive clean/reset commands are intentionally limited to this helper-owned temp directory.
+if (-not (Test-Path (Join-Path $LiteRtRoot ".git"))) {
+  if (Test-Path $LiteRtRoot) {
+    Remove-Item -Recurse -Force $LiteRtRoot
+  }
+  Invoke-Checked $Git @("clone", "--filter=blob:none", "https://github.com/google-ai-edge/LiteRT.git", $LiteRtRoot) ([IO.Path]::GetTempPath())
+}
+Invoke-Checked $Git @("fetch", "--depth=1", "origin", $LiteRtRef) $LiteRtRoot
+Invoke-Checked $Git @("checkout", "--detach", $LiteRtRef) $LiteRtRoot
+Invoke-Checked $Git @("reset", "--hard", $LiteRtRef) $LiteRtRoot
+Invoke-Checked $Git @("clean", "-fdx") $LiteRtRoot
+Invoke-Checked $Git @("apply", "--check", $LiteRtPatch) $LiteRtRoot
+Invoke-Checked $Git @("apply", $LiteRtPatch) $LiteRtRoot
+
+$Override = $LiteRtRoot.Replace("\", "/")
+$CommonArgs = @(
+  "--config=windows",
+  "--define=litert_runtime_link_mode=dynamic",
+  "--define=resolve_symbols_in_exec=false",
+  "--override_repository=litert=$Override"
+)
+$MainTarget = "//runtime/engine:litert_lm_main"
+$AcceleratorTarget = "@litert//litert/runtime/accelerators/gpu:libLiteRtWebGpuAccelerator"
+
+Invoke-Checked $Bazel (@("build") + $CommonArgs + @($MainTarget, $AcceleratorTarget))
+
+$MainExe = Resolve-BazelOutput $Bazel $CommonArgs $MainTarget ".exe"
+$AcceleratorDll = Resolve-BazelOutput $Bazel $CommonArgs $AcceleratorTarget ".dll"
+
+if (Test-Path $OutputRoot) {
+  Remove-Item -Recurse -Force $OutputRoot
+}
+New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
+
+Copy-Item $MainExe (Join-Path $OutputRoot "litert_lm_main.exe") -Force
+Copy-Item (Join-Path $PrebuiltRoot "*.dll") $OutputRoot -Force
+# Always replace Google's bundled accelerator with the one built from the patched LiteRT source.
+Copy-Item $AcceleratorDll (Join-Path $OutputRoot "libLiteRtWebGpuAccelerator.dll") -Force
+
+$PatchedDll = Join-Path $OutputRoot "libLiteRtWebGpuAccelerator.dll"
+Assert-NotLfsPointer $PatchedDll
+
+Write-Host ""
+Write-Host "Patched Windows GPU bundle created:" -ForegroundColor Green
+Write-Host "  $OutputRoot"
+Write-Host "Patched accelerator:" -ForegroundColor Green
+Write-Host "  $PatchedDll"
+Write-Host ""
+Write-Host "Expected NVIDIA/D3D12 test log:" -ForegroundColor Yellow
+Write-Host "  1. Dawn/WebGPU selects your NVIDIA adapter (RTX 3080 on the target machine)."
+Write-Host "  2. 'Windows WebGPU: disabling asynchronous weight uploads ...'"
+Write-Host "  3. '# of threads to upload weights = 0'"
+Write-Host "  4. Model initialization and generation complete without the prior access violation/segfault."
+Write-Host ""
+Write-Host "This mitigation serializes weight upload only; GPU inference remains enabled." -ForegroundColor Yellow
+
+if ($ModelPath) {
+  $ResolvedModel = (Resolve-Path $ModelPath).Path
+  Write-Host ""
+  Write-Host "Launching RTX GPU smoke test..." -ForegroundColor Green
+  $TestExe = Join-Path $OutputRoot "litert_lm_main.exe"
+  Invoke-Checked $TestExe @(
+    "--backend=gpu",
+    "--model_path=$ResolvedModel",
+    "--input_prompt=$Prompt"
+  ) $OutputRoot
+} else {
+  Write-Host ""
+  Write-Host "To run immediately with a model:" -ForegroundColor Cyan
+  Write-Host ".\tools\windows\build_nvidia_webgpu_test.ps1 -ModelPath 'C:\path\to\model.litertlm'"
+  Write-Host ""
+  Write-Host "Or run the built bundle manually:" -ForegroundColor Cyan
+  Write-Host "cd '$OutputRoot'"
+  Write-Host ".\litert_lm_main.exe --backend=gpu --model_path='C:\path\to\model.litertlm' --input_prompt='Hello from the RTX 3080'"
+}


### PR DESCRIPTION
Patched your LiteRT-LM fork for a focused **Windows + NVIDIA RTX 3080 / D3D12 WebGPU** test.

Branch: **[`[agent/fix-windows-nvidia-webgpu-upload](https://github.com/ornab74/LiteRT-LM/tree/agent/fix-windows-nvidia-webgpu-upload)`](https://github.com/ornab74/LiteRT-LM/tree/agent/fix-windows-nvidia-webgpu-upload)**

The branch is 3 commits ahead of `main` and contains only:

* `PATCH.litert_windows_nvidia_webgpu_upload`
* `tools/windows/build_nvidia_webgpu_test.ps1`
* `WINDOWS_NVIDIA_WEBGPU_TEST.md`

The Windows build helper rebuilds the actual `libLiteRtWebGpuAccelerator.dll` from the patched LiteRT dependency instead of accidentally testing Google's existing prebuilt DLL.

### Test it on the RTX 3080

On the Windows/NVIDIA machine:

```powershell
git clone -b agent/fix-windows-nvidia-webgpu-upload https://github.com/ornab74/LiteRT-LM.git
cd LiteRT-LM

git lfs install
git lfs pull
```

Then build and test directly:

```powershell
.\tools\windows\build_nvidia_webgpu_test.ps1 `
  -ModelPath "C:\path\to\gemma-4-E2B-it.litertlm" `
  -Prompt "Reply with exactly: RTX GPU OK"
```

Or build without launching:

```powershell
.\tools\windows\build_nvidia_webgpu_test.ps1
```

Output goes to:

```text
out\windows-nvidia-webgpu\
```

You can then run:

```powershell
cd out\windows-nvidia-webgpu

.\litert_lm_main.exe `
  --backend=gpu `
  --model_path="C:\path\to\gemma-4-E2B-it.litertlm" `
  --input_prompt="Reply with exactly: RTX GPU OK"
```

### What we want to see

The critical console sequence is approximately:

```text
NVIDIA ...
D3D12 ...
WebGPU ...

Windows WebGPU: disabling asynchronous weight uploads (requested 2 threads); D3D12 GPU execution remains enabled.

# of threads to upload weights = 0
```

Then initialization should continue and produce:

```text
RTX GPU OK
```

The important part is that it remains:

```text
--backend=gpu
```

This patch **does not switch NVIDIA to CPU**. It keeps Dawn/WebGPU/D3D12 GPU inference enabled while serializing the Windows model-weight upload operation that appears to be triggering the NVIDIA crashes.

LiteRT-LM's own source-build documentation confirms the Windows executable target is `//runtime/engine:litert_lm_main` and that GPU builds need the dynamic LiteRT runtime DLL setup we're using.

### Why this is a good first patch

The NVIDIA reports we've been tracing aren't showing:

> No NVIDIA GPU found

They're showing approximately:

```text
NVIDIA adapter found
D3D12 adapter selected
WebGPU environment created
# of threads to upload weights = 2
CRASH
```

So adding CUDA detection wouldn't address the actual failure.

Our patch instead changes the vulnerable Windows initialization sequence to:

```text
NVIDIA adapter
    ↓
D3D12
    ↓
Dawn / WebGPU
    ↓
GPU device created
    ↓
serialized weight upload    ← PATCH
    ↓
GPU inference
```

rather than:

```text
NVIDIA adapter
    ↓
D3D12
    ↓
Dawn / WebGPU
    ↓
multiple concurrent weight-upload workers
    ↓
💥 access violation / segfault
```

### If it still crashes

That result will also be useful.

If you get:

```text
Windows WebGPU: disabling asynchronous weight uploads
# of threads to upload weights = 0
```

**and it still crashes**, we've eliminated the upload-thread race as the primary cause. The next isolated patch I would test is the Windows/D3D12 `enable_host_mapped_pointer` path.

 