### PR TITLE
apple_fm: constrained tool calling, bounded thinking, trained-format tool lists (follow-up to #3264)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /MODULE.bazel.lock
 /bazel-*
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -78,6 +78,18 @@ let package = Package(
         "AdapterTests.swift",
       ]
     ),
+    // Headless macOS driver for the adapter (swift/apple_fm/main.swift), so the
+    // same Swift path an iOS app takes can be run without a device.
+    .executableTarget(
+      name: "fmtest",
+      dependencies: ["LiteRTLM", "LiteRTLMFoundationModels"],
+      path: "swift/apple_fm",
+      exclude: [
+        "AdapterTests.swift", "BUILD", "CGImagePNG.swift", "LiteRTLanguageModel.swift",
+        "LiteRTSegments.swift",
+      ],
+      sources: ["main.swift"]
+    ),
     // Separate test targets for each file to avoid naming conflicts:
     .testTarget(
       name: "ModelInfoTests",
@@ -114,6 +126,12 @@ let package = Package(
       dependencies: ["LiteRTLM"],
       path: "swift",
       sources: ["MessageTests.swift"]
+    ),
+    .testTarget(
+      name: "AdapterTests",
+      dependencies: ["LiteRTLM", "LiteRTLMFoundationModels"],
+      path: "swift/apple_fm",
+      sources: ["AdapterTests.swift"]
     ),
   ]
 )

--- a/swift/Config.swift
+++ b/swift/Config.swift
@@ -184,6 +184,11 @@ public struct ConversationConfig {
   public let enableToolCallStreaming: Bool
   public let thinkingConfig: ThinkingConfig?
   public let automaticToolCalling: Bool
+  /// Tool descriptions as the engine's own JSON, for a host that already has a
+  /// tool registry of its own. `tools` builds this from Swift types via
+  /// reflection, which a host whose tools are values rather than types cannot
+  /// use. When set, this is passed through untouched.
+  public let toolsJsonOverride: String?
   public let enableResponseFormat: Bool
   public let visualTokenBudget: Int32?
   public let enableSpeculativeDecoding: Bool?
@@ -219,6 +224,7 @@ public struct ConversationConfig {
     enableToolCallStreaming: Bool = false,
     thinkingConfig: ThinkingConfig? = nil,
     automaticToolCalling: Bool = true,
+    toolsJsonOverride: String? = nil,
     enableResponseFormat: Bool = false,
     visualTokenBudget: Int32? = nil,
     enableSpeculativeDecoding: Bool? = nil
@@ -238,6 +244,7 @@ public struct ConversationConfig {
     self.enableToolCallStreaming = enableToolCallStreaming
     self.thinkingConfig = thinkingConfig
     self.automaticToolCalling = automaticToolCalling
+    self.toolsJsonOverride = toolsJsonOverride
     self.enableResponseFormat = enableResponseFormat
     self.visualTokenBudget = visualTokenBudget
     self.enableSpeculativeDecoding = enableSpeculativeDecoding

--- a/swift/ConversationTests.swift
+++ b/swift/ConversationTests.swift
@@ -31,7 +31,7 @@ class ConversationTests: XCTestCase {
   override func setUp() async throws {
     try await super.setUp()
     let modelResource =
-      + "runtime/testdata/test_lm.litertlm"
+      "runtime/testdata/test_lm.litertlm"
     let modelPath = testDataPath(forResource: modelResource)
     ExperimentalFlags.optIntoExperimentalAPIs()
     ExperimentalFlags.enableBenchmark = true
@@ -506,7 +506,7 @@ class ConversationTests: XCTestCase {
 
   func testConversationTeardownAndEngineRetentionDoesNotCrash() async throws {
     let modelResource =
-      + "runtime/testdata/test_lm.litertlm"
+      "runtime/testdata/test_lm.litertlm"
     var localEngine: Engine? = Engine(
       engineConfig: try EngineConfig(
         modelPath: testDataPath(forResource: modelResource),

--- a/swift/Engine.swift
+++ b/swift/Engine.swift
@@ -166,7 +166,8 @@ public actor Engine {
     let toolManager = ToolManager(tools: conversationConfig.tools)
 
     let systemMessageJsonStr = (try? conversationConfig.systemMessage?.contents.jsonString) ?? ""
-    let toolDescriptionJsonStr = toolManager.toolsJsonDescription
+    let toolDescriptionJsonStr =
+      conversationConfig.toolsJsonOverride ?? toolManager.toolsJsonDescription
 
     let initialMessagesJson = conversationConfig.initialMessages.map { $0.toJson }
     let messagesJsonStr: String

--- a/swift/apple_fm/AdapterTests.swift
+++ b/swift/apple_fm/AdapterTests.swift
@@ -298,6 +298,34 @@
         "still open, never closed")
     }
 
+    // MARK: - Native tool calls
+
+    /// The model writes its calls Python-style. `True` is a boolean, not the
+    /// string "True" (device run 2026-09-04: `set_torch(on=True)` reached FM
+    /// as a string and the call failed), and a doubled closer must not leak
+    /// into the last value.
+    func testNativeToolCallParsesPythonBooleansAndStrayClosers() throws {
+      let call = try XCTUnwrap(
+        LiteRTLMExecutor.parseNativeToolCall(
+          "<|tool_call_start|>[set_torch(on=True)]<|tool_call_end|>"))
+      XCTAssertEqual(call.name, "set_torch")
+      XCTAssertEqual(call.arguments, #"{"on":true}"#)
+
+      let doubled = try XCTUnwrap(
+        LiteRTLMExecutor.parseNativeToolCall(
+          "<|tool_call_start|>[set_torch(on=False))]<|tool_call_end|>"))
+      XCTAssertEqual(doubled.arguments, #"{"on":false}"#)
+
+      let mixed = try XCTUnwrap(
+        LiteRTLMExecutor.parseNativeToolCall(
+          "<|tool_call_start|>[translate(source='a, b)', to=\"ja\", n=2)]<|tool_call_end|>"))
+      let data = try XCTUnwrap(mixed.arguments.data(using: .utf8))
+      let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      XCTAssertEqual(object["source"] as? String, "a, b)")
+      XCTAssertEqual(object["to"] as? String, "ja")
+      XCTAssertEqual(object["n"] as? Int, 2)
+    }
+
     // MARK: - Guided generation
 
     /// The mode is a conversation-level choice, so two models over one engine

--- a/swift/apple_fm/AdapterTests.swift
+++ b/swift/apple_fm/AdapterTests.swift
@@ -211,6 +211,93 @@
       XCTAssertLessThan(apple.lowerBound, mango.lowerBound)
       XCTAssertLessThan(mango.lowerBound, zebra.lowerBound)
     }
+
+    // MARK: - Tool routing
+
+    /// The router grammar must stay inside object/properties/required/enum/string.
+    /// Anything richer (anyOf, if/then) is not safe to assume of a JSON-Schema
+    /// grammar compiler, and a schema the compiler rejects silently drops the
+    /// constraint — the failure this whole path exists to prevent.
+    func testRouteSchemaEnumeratesEveryToolPlusTheSentinel() throws {
+      let tools = try Self.toolDefinitions()
+      let schema = LiteRTLMExecutor.routeSchema(tools)
+
+      XCTAssertEqual(schema["type"] as? String, "object")
+      XCTAssertEqual(Set(schema["required"] as? [String] ?? []), ["tool", "answer"])
+
+      let properties = try XCTUnwrap(schema["properties"] as? [String: Any])
+      let tool = try XCTUnwrap(properties["tool"] as? [String: Any])
+      XCTAssertEqual(
+        tool["enum"] as? [String],
+        [LiteRTLMExecutor.noToolSentinel, "get_temperature", "open_url"])
+      XCTAssertEqual((properties["answer"] as? [String: Any])?["type"] as? String, "string")
+
+      // And it has to survive the encoder that hands it to the runtime.
+      XCTAssertNoThrow(try ResponseFormat.json(schema: schema))
+    }
+
+    /// A tool name equal to the sentinel would make "no tool" unaddressable. It
+    /// must not end up in the enum twice; the tool loses, since the sentinel is
+    /// the only way to answer without calling anything.
+    func testRouteSchemaDoesNotDuplicateTheSentinel() throws {
+      let tools = try Self.toolDefinitions()
+      let schema = LiteRTLMExecutor.routeSchema(tools + tools)
+      let properties = try XCTUnwrap(schema["properties"] as? [String: Any])
+      let names = try XCTUnwrap((properties["tool"] as? [String: Any])?["enum"] as? [String])
+      XCTAssertEqual(names.filter { $0 == LiteRTLMExecutor.noToolSentinel }.count, 1)
+    }
+
+    func testParseRouteSelectsTheNamedTool() throws {
+      let tools = try Self.toolDefinitions()
+      let route = LiteRTLMExecutor.parseRoute(
+        from: #"{"tool": "get_temperature", "answer": ""}"#, tools: tools)
+      XCTAssertEqual(route.tool?.name, "get_temperature")
+    }
+
+    func testParseRouteTreatsTheSentinelAsAnAnswer() throws {
+      let tools = try Self.toolDefinitions()
+      let route = LiteRTLMExecutor.parseRoute(
+        from: #"{"tool": "none", "answer": "42"}"#, tools: tools)
+      XCTAssertNil(route.tool)
+      XCTAssertEqual(route.answer, "42")
+    }
+
+    func testParseRouteRejectsAToolThatWasNotOffered() throws {
+      let tools = try Self.toolDefinitions()
+      let route = LiteRTLMExecutor.parseRoute(
+        from: #"{"tool": "rm_rf", "answer": ""}"#, tools: tools)
+      XCTAssertNil(route.tool)
+    }
+
+    /// Constrained decoding is not guaranteed — a runtime built without it, or a
+    /// schema the compiler refused, both land here. Free text must degrade to a
+    /// plain answer rather than to an empty turn.
+    func testParseRouteFallsBackToRawTextWhenTheReplyIsNotJSON() throws {
+      let tools = try Self.toolDefinitions()
+      let route = LiteRTLMExecutor.parseRoute(from: "It is 21 degrees.", tools: tools)
+      XCTAssertNil(route.tool)
+      XCTAssertEqual(route.answer, "It is 21 degrees.")
+    }
+
+    /// `Transcript.ToolDefinition` values as FM itself builds them, taken off a
+    /// session rather than constructed by hand.
+    private static func toolDefinitions() throws -> [Transcript.ToolDefinition] {
+      [
+        Transcript.ToolDefinition(tool: StubTool()),
+        Transcript.ToolDefinition(tool: OpenURLTool()),
+      ]
+    }
+  }
+
+  @available(iOS 27.0, macOS 27.0, *)
+  private struct OpenURLTool: FoundationModels.Tool {
+    let name = "open_url"
+    let description = "Open a web page."
+    @Generable struct Arguments {
+      @Guide(description: "The URL to open")
+      var url: String
+    }
+    func call(arguments: Arguments) async throws -> String { "opened" }
   }
 
   /// Properties intentionally declared out of alphabetical order, so the sorted

--- a/swift/apple_fm/AdapterTests.swift
+++ b/swift/apple_fm/AdapterTests.swift
@@ -212,6 +212,92 @@
       XCTAssertLessThan(mango.lowerBound, zebra.lowerBound)
     }
 
+    // MARK: - Tool list encoding
+
+    /// The chat template `tojson`s each entry verbatim into the prompt, so the
+    /// string this produces is exactly what the model reads. `.bare` is LFM2's
+    /// trained format: no OpenAI envelope, `name` first, schema keys in trained
+    /// order, none of FM's bookkeeping left anywhere in it.
+    func testBareToolListMatchesTheTrainedFormat() throws {
+      let json = LiteRTLMExecutor.toolsJson(try Self.toolDefinitions(), style: .bare)
+
+      XCTAssertFalse(json.contains("\"function\""))
+      XCTAssertFalse(json.contains("\"title\""))
+      XCTAssertFalse(json.contains("x-order"))
+      XCTAssertFalse(json.contains("additionalProperties"))
+      XCTAssertTrue(
+        json.hasPrefix("[{\"name\": \"get_temperature\", \"description\": "),
+        "entries must open with the tool's name, not with whatever key sorts first: \(json)")
+      let type = try XCTUnwrap(json.range(of: "{\"type\": \"object\""))
+      let properties = try XCTUnwrap(json.range(of: "\"properties\"", range: type.lowerBound..<json.endIndex))
+      let required = try XCTUnwrap(json.range(of: "\"required\"", range: type.lowerBound..<json.endIndex))
+      XCTAssertLessThan(type.lowerBound, properties.lowerBound)
+      XCTAssertLessThan(properties.lowerBound, required.lowerBound)
+
+      // Still one valid JSON array of one object per tool.
+      let parsed = try XCTUnwrap(
+        try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [[String: Any]])
+      XCTAssertEqual(parsed.count, 2)
+      XCTAssertEqual(parsed.map { $0["name"] as? String }, ["get_temperature", "open_url"])
+    }
+
+    /// The default stays OpenAI-shaped for models (Qwen, Gemma) trained on the
+    /// envelope — but FM's bookkeeping is stripped there too.
+    func testDefaultToolListKeepsTheEnvelope() throws {
+      let json = LiteRTLMExecutor.toolsJson(try Self.toolDefinitions())
+      let parsed = try XCTUnwrap(
+        try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [[String: Any]])
+      XCTAssertEqual(parsed.count, 2)
+      for entry in parsed {
+        XCTAssertEqual(entry["type"] as? String, "function")
+        XCTAssertNotNil(entry["function"])
+      }
+      XCTAssertFalse(json.contains("\"title\""))
+      XCTAssertFalse(json.contains("additionalProperties"))
+    }
+
+    /// Embedded in the prompt, so it must not vary run to run — dictionary key
+    /// order is randomized per process.
+    func testToolListEncodingIsDeterministic() throws {
+      let tools = try Self.toolDefinitions()
+      let first = LiteRTLMExecutor.toolsJson(tools, style: .bare)
+      for _ in 0..<32 {
+        XCTAssertEqual(LiteRTLMExecutor.toolsJson(tools, style: .bare), first)
+      }
+    }
+
+    /// A tool without arguments is a name and a description — an empty
+    /// `parameters` object invites the model to invent some.
+    func testToolWithoutArgumentsCarriesNoParameters() throws {
+      let json = LiteRTLMExecutor.toolsJson(
+        [Transcript.ToolDefinition(tool: NoArgumentsTool())], style: .bare)
+      XCTAssertFalse(json.contains("\"parameters\""))
+      XCTAssertFalse(json.contains("\"required\""))
+    }
+
+    // MARK: - Thinking leak
+
+    /// The budget force-closes `</think>` mid-thought; the model keeps
+    /// reasoning into the visible stream and closes again itself. Only what
+    /// follows the last closer is the answer.
+    func testVisibleAnswerDropsLeakedThought() {
+      XCTAssertEqual(
+        LiteRTLMExecutor.visibleAnswer(
+          "I am near CAFE LA. Let me answer as requested.</think>You are near CAFE LA."),
+        "You are near CAFE LA.")
+      XCTAssertEqual(
+        LiteRTLMExecutor.visibleAnswer("first</think>middle</think> final answer "),
+        "final answer")
+    }
+
+    func testVisibleAnswerKeepsPlainRepliesAndEmptiesThoughtOnly() {
+      XCTAssertEqual(
+        LiteRTLMExecutor.visibleAnswer("  You are in Chuo, Osaka. "), "You are in Chuo, Osaka.")
+      XCTAssertEqual(LiteRTLMExecutor.visibleAnswer("all of this was reasoning</think>"), "")
+      XCTAssertEqual(LiteRTLMExecutor.visibleAnswer("<think>still open, never closed"),
+        "still open, never closed")
+    }
+
     // MARK: - Tool routing
 
     /// The router grammar must stay inside object/properties/required/enum/string.
@@ -298,6 +384,14 @@
       var url: String
     }
     func call(arguments: Arguments) async throws -> String { "opened" }
+  }
+
+  @available(iOS 27.0, macOS 27.0, *)
+  private struct NoArgumentsTool: FoundationModels.Tool {
+    let name = "get_time"
+    let description = "The current time."
+    @Generable struct Arguments {}
+    func call(arguments: Arguments) async throws -> String { "12:00" }
   }
 
   /// Properties intentionally declared out of alphabetical order, so the sorted

--- a/swift/apple_fm/AdapterTests.swift
+++ b/swift/apple_fm/AdapterTests.swift
@@ -298,72 +298,142 @@
         "still open, never closed")
     }
 
-    // MARK: - Tool routing
+    // MARK: - Guided generation
 
-    /// The router grammar must stay inside object/properties/required/enum/string.
-    /// Anything richer (anyOf, if/then) is not safe to assume of a JSON-Schema
-    /// grammar compiler, and a schema the compiler rejects silently drops the
-    /// constraint — the failure this whole path exists to prevent.
-    func testRouteSchemaEnumeratesEveryToolPlusTheSentinel() throws {
+    /// The mode is a conversation-level choice, so two models over one engine
+    /// configuration in different modes share the engine.
+    func testGuidedGenerationModesShareOneEngine() throws {
+      let config = try EngineConfig(modelPath: Self.modelPath, backend: .cpu())
+      let constrained = LiteRTLanguageModel(engineConfig: config)
+      let promptOnly = LiteRTLanguageModel(engineConfig: config, guidedGeneration: .promptOnly)
+      XCTAssertEqual(constrained.guidedGeneration, .constrained)
+      XCTAssertEqual(promptOnly.guidedGeneration, .promptOnly)
+
+      let a = LanguageModelSession(model: constrained)
+      a.prewarm()
+      let b = LanguageModelSession(model: promptOnly)
+      b.prewarm()
+
+      withExtendedLifetime((a, b)) {
+        XCTAssertEqual(EngineCache.shared.count, 1)
+      }
+    }
+
+    /// The schema goes into the trigger prompt and nowhere else. When the
+    /// caller keeps it out of the prompt (`includeSchemaInPrompt: false`) the
+    /// trigger is the user's words alone, whatever the engine enforces.
+    func testPlanWritesTheSchemaIntoTheTriggerOnly() throws {
+      let schema = #"{"type":"object"}"#
+      let transcript = Transcript(entries: [
+        .instructions(
+          Transcript.Instructions(
+            segments: [.text(.init(content: "Be brief."))], toolDefinitions: [])),
+        .prompt(Transcript.Prompt(segments: [.text(.init(content: "Hi"))])),
+        .prompt(Transcript.Prompt(segments: [.text(.init(content: "List the colors"))])),
+      ])
+
+      let hinted = try LiteRTLMExecutor.plan(
+        from: transcript, schemaJSON: schema, guided: true, tools: [])
+      XCTAssertEqual(hinted.systemText, "Be brief.")
+      XCTAssertTrue(hinted.prompt.toString.hasPrefix("List the colors"))
+      XCTAssertTrue(hinted.prompt.toString.contains(schema))
+      XCTAssertEqual(hinted.history.map(\.toString), ["Hi"])
+      XCTAssertFalse(hinted.respondingToTool)
+
+      let bare = try LiteRTLMExecutor.plan(
+        from: transcript, schemaJSON: nil, guided: true, tools: [])
+      XCTAssertEqual(bare.prompt.toString, "List the colors")
+    }
+
+    /// On the turn that answers a tool result, a guided request asks for the
+    /// structure; the plain turn asks for a sentence and forbids JSON.
+    func testPlanToolResultTriggerFollowsTheTurnKind() throws {
       let tools = try Self.toolDefinitions()
-      let schema = LiteRTLMExecutor.routeSchema(tools)
+      let transcript = Transcript(entries: [
+        .prompt(Transcript.Prompt(segments: [.text(.init(content: "Weather?"))])),
+        .toolOutput(
+          Transcript.ToolOutput(
+            id: "1", toolName: "get_temperature", segments: [.text(.init(content: "21°C"))])),
+      ])
 
-      XCTAssertEqual(schema["type"] as? String, "object")
-      XCTAssertEqual(Set(schema["required"] as? [String] ?? []), ["tool", "answer"])
+      let plain = try LiteRTLMExecutor.plan(from: transcript, schemaJSON: nil, tools: tools)
+      XCTAssertTrue(plain.respondingToTool)
+      XCTAssertEqual(plain.toolResult, "21°C")
+      XCTAssertEqual(plain.toolRounds, 1)
+      XCTAssertTrue(plain.prompt.toString.contains("Do not output JSON"))
 
-      let properties = try XCTUnwrap(schema["properties"] as? [String: Any])
-      let tool = try XCTUnwrap(properties["tool"] as? [String: Any])
+      let schema = #"{"type":"object"}"#
+      let guided = try LiteRTLMExecutor.plan(
+        from: transcript, schemaJSON: schema, guided: true, tools: tools)
+      XCTAssertTrue(guided.respondingToTool)
+      XCTAssertFalse(guided.prompt.toString.contains("Do not output JSON"))
+      XCTAssertTrue(guided.prompt.toString.contains("Tool \"get_temperature\" returned: 21°C"))
+      XCTAssertTrue(guided.prompt.toString.contains("Using that result, respond with ONLY"))
+      XCTAssertTrue(guided.prompt.toString.contains(schema))
+    }
+
+    /// Under the grammar the prompt names only the keys, in declared order:
+    /// the engine holds the types and the enum values, and every further word
+    /// in the hint was something the model copied into a value.
+    func testSchemaHintUnderTheConstraintNamesOnlyTheKeys() {
+      let hint = LiteRTLMExecutor.schemaHint(Self.orderSchema, constrained: true)
       XCTAssertEqual(
-        tool["enum"] as? [String],
-        [LiteRTLMExecutor.noToolSentinel, "get_temperature", "open_url"])
-      XCTAssertEqual((properties["answer"] as? [String: Any])?["type"] as? String, "string")
-
-      // And it has to survive the encoder that hands it to the runtime.
-      XCTAssertNoThrow(try ResponseFormat.json(schema: schema))
+        hint,
+        "Respond with ONLY a JSON object with exactly these keys, in this order: "
+          + "item, size, quantity, extras. Output valid JSON and nothing else.")
     }
 
-    /// A tool name equal to the sentinel would make "no tool" unaddressable. It
-    /// must not end up in the enum twice; the tool loses, since the sentinel is
-    /// the only way to answer without calling anything.
-    func testRouteSchemaDoesNotDuplicateTheSentinel() throws {
-      let tools = try Self.toolDefinitions()
-      let schema = LiteRTLMExecutor.routeSchema(tools + tools)
-      let properties = try XCTUnwrap(schema["properties"] as? [String: Any])
-      let names = try XCTUnwrap((properties["tool"] as? [String: Any])?["enum"] as? [String])
-      XCTAssertEqual(names.filter { $0 == LiteRTLMExecutor.noToolSentinel }.count, 1)
+    /// A schema as Foundation Models encodes one — `x-order`, `title`,
+    /// descriptions, an enum, an optional — rendered for the prompt: one line
+    /// per field in declared order, and none of the schema's own vocabulary
+    /// for the model to echo.
+    func testSchemaHintListsFieldsInDeclaredOrder() throws {
+      let hint = LiteRTLMExecutor.schemaHint(Self.orderSchema)
+      let item = try XCTUnwrap(hint.range(of: "- item (string): The drink ordered"))
+      let size = try XCTUnwrap(hint.range(of: "- size (string, one of: small, medium, large)"))
+      let quantity = try XCTUnwrap(hint.range(of: "- quantity (integer)"))
+      let extras = try XCTUnwrap(hint.range(of: "- extras (array of string, optional)"))
+      XCTAssertLessThan(item.lowerBound, size.lowerBound)
+      XCTAssertLessThan(size.lowerBound, quantity.lowerBound)
+      XCTAssertLessThan(quantity.lowerBound, extras.lowerBound)
+      XCTAssertFalse(hint.contains("x-order"))
+      XCTAssertFalse(hint.contains("CoffeeOrder"))
+      XCTAssertTrue(hint.hasSuffix("Output valid JSON and nothing else."))
     }
 
-    func testParseRouteSelectsTheNamedTool() throws {
-      let tools = try Self.toolDefinitions()
-      let route = LiteRTLMExecutor.parseRoute(
-        from: #"{"tool": "get_temperature", "answer": ""}"#, tools: tools)
-      XCTAssertEqual(route.tool?.name, "get_temperature")
+    /// A schema with no properties — a bare type — is shown as it is.
+    func testSchemaHintFallsBackToTheRawSchemaWithoutProperties() {
+      let hint = LiteRTLMExecutor.schemaHint(#"{"type":"string"}"#)
+      XCTAssertTrue(hint.contains(#"{"type":"string"}"#))
+      XCTAssertTrue(hint.hasSuffix("Output valid JSON and nothing else."))
     }
 
-    func testParseRouteTreatsTheSentinelAsAnAnswer() throws {
-      let tools = try Self.toolDefinitions()
-      let route = LiteRTLMExecutor.parseRoute(
-        from: #"{"tool": "none", "answer": "42"}"#, tools: tools)
-      XCTAssertNil(route.tool)
-      XCTAssertEqual(route.answer, "42")
+    /// The engine sees the properties in `x-order` — the order the model
+    /// fills them in under the grammar — with the bookkeeping keys gone, and
+    /// the same text every time.
+    func testEngineSchemaFollowsDeclaredOrder() throws {
+      let engine = LiteRTLMExecutor.engineSchema(Self.orderSchema)
+      let item = try XCTUnwrap(engine.range(of: "\"item\""))
+      let size = try XCTUnwrap(engine.range(of: "\"size\""))
+      let quantity = try XCTUnwrap(engine.range(of: "\"quantity\""))
+      let extras = try XCTUnwrap(engine.range(of: "\"extras\""))
+      XCTAssertLessThan(item.lowerBound, size.lowerBound)
+      XCTAssertLessThan(size.lowerBound, quantity.lowerBound)
+      XCTAssertLessThan(quantity.lowerBound, extras.lowerBound)
+      XCTAssertFalse(engine.contains("x-order"))
+      XCTAssertFalse(engine.contains("\"title\""))
+      XCTAssertTrue(engine.contains("\"required\":[\"item\",\"size\",\"quantity\"]"))
+      for _ in 0..<16 {
+        XCTAssertEqual(LiteRTLMExecutor.engineSchema(Self.orderSchema), engine)
+      }
+      XCTAssertNoThrow(try ResponseFormat.json(schema: engine))
     }
 
-    func testParseRouteRejectsAToolThatWasNotOffered() throws {
-      let tools = try Self.toolDefinitions()
-      let route = LiteRTLMExecutor.parseRoute(
-        from: #"{"tool": "rm_rf", "answer": ""}"#, tools: tools)
-      XCTAssertNil(route.tool)
-    }
-
-    /// Constrained decoding is not guaranteed — a runtime built without it, or a
-    /// schema the compiler refused, both land here. Free text must degrade to a
-    /// plain answer rather than to an empty turn.
-    func testParseRouteFallsBackToRawTextWhenTheReplyIsNotJSON() throws {
-      let tools = try Self.toolDefinitions()
-      let route = LiteRTLMExecutor.parseRoute(from: "It is 21 degrees.", tools: tools)
-      XCTAssertNil(route.tool)
-      XCTAssertEqual(route.answer, "It is 21 degrees.")
-    }
+    /// Sorted-keys encoding of a four-field schema, as `encodeSchema` emits it:
+    /// alphabetical, with `x-order` carrying the declared order.
+    private static let orderSchema = #"""
+      {"additionalProperties":false,"properties":{"extras":{"description":"Extras asked for","items":{"type":"string"},"type":"array"},"item":{"description":"The drink ordered","type":"string"},"quantity":{"description":"How many cups","type":"integer"},"size":{"description":"Cup size","enum":["small","medium","large"],"type":"string"}},"required":["item","size","quantity"],"title":"CoffeeOrder","type":"object","x-order":["item","size","quantity","extras"]}
+      """#
 
     /// `Transcript.ToolDefinition` values as FM itself builds them, taken off a
     /// session rather than constructed by hand.

--- a/swift/apple_fm/LiteRTLanguageModel.swift
+++ b/swift/apple_fm/LiteRTLanguageModel.swift
@@ -164,12 +164,20 @@
       // Guided generation: if the request carries a schema, encode it to JSON,
       // steer the model via the prompt (schema-in-prompt), and additionally
       // constrain decoding to the schema (llguidance), which makes it impossible
-      // for the output to deviate from it. Tools: if enabled, describe them in the
-      // prompt and detect a tool-call in the output (soft / prompt-driven).
+      // for the output to deviate from it.
+      //
+      // Tools take the same treatment, in two constrained steps: first the model
+      // picks a tool name (or "none") out of an enum, then — only if it picked one
+      // — it fills that tool's own parameter schema. A single combined schema
+      // would need `anyOf` to switch the argument shape on the chosen name; the
+      // split keeps every grammar to enum/object/required, which is the part of
+      // JSON Schema that is safe to assume, and it constrains the arguments
+      // rather than hoping the model spells them right.
       let tools = request.enabledToolDefinitions
       let schemaJSON = request.schema.flatMap { try? Self.encodeSchema($0) }
       let plan = try Self.plan(from: request.transcript, schemaJSON: schemaJSON, tools: tools)
       let responseFormat = schemaJSON.flatMap { try? ResponseFormat.json(schema: $0) }
+      let routeFormat = tools.isEmpty ? nil : try? ResponseFormat.json(schema: Self.routeSchema(tools))
 
       let structured = schemaJSON != nil || !tools.isEmpty
       let conversation = try await engine.createConversation(
@@ -177,22 +185,41 @@
           systemMessage: plan.systemMessage,
           initialMessages: plan.history,
           samplerConfig: Self.sampler(for: request.generationOptions, structured: structured),
-          enableResponseFormat: responseFormat != nil,
+          enableResponseFormat: responseFormat != nil || routeFormat != nil,
           visualTokenBudget: model.visualTokenBudget))
 
       if !tools.isEmpty {
-        var full = ""
-        for try await chunk in conversation.sendMessageStream(plan.prompt) {
-          full += chunk.toString
+        var routeText = ""
+        for try await chunk in conversation.sendMessageStream(
+          plan.prompt, responseFormat: routeFormat)
+        {
+          routeText += chunk.toString
         }
-        if let call = Self.parseToolCall(from: full, tools: tools) {
+        let route = Self.parseRoute(from: routeText, tools: tools)
+
+        if let tool = route.tool {
+          // The chosen tool's parameter schema is the grammar for this second
+          // pass, so the arguments cannot come back malformed or under-filled.
+          let argsFormat = (try? Self.encodeSchema(tool.parameters)).flatMap {
+            try? ResponseFormat.json(schema: $0)
+          }
+          var argsText = ""
+          for try await chunk in conversation.sendMessageStream(
+            Message(Self.argumentsRequest(for: tool), role: .user), responseFormat: argsFormat)
+          {
+            argsText += chunk.toString
+          }
+          let arguments = Self.extractJSONObject(from: argsText) ?? "{}"
           await channel.send(
             .toolCalls(
               action: .toolCall(
-                id: UUID().uuidString, name: call.name,
-                action: .appendArguments(call.arguments, tokenCount: call.arguments.count))))
+                id: UUID().uuidString, name: tool.name,
+                action: .appendArguments(arguments, tokenCount: arguments.count))))
         } else {
-          await channel.send(.response(action: .appendText(full, tokenCount: full.count)))
+          // "none": the same constrained pass already carries the reply, so a
+          // plain chat turn still costs one generation.
+          let answer = route.answer.isEmpty ? routeText : route.answer
+          await channel.send(.response(action: .appendText(answer, tokenCount: answer.count)))
         }
       } else if schemaJSON != nil {
         var full = ""
@@ -315,6 +342,11 @@
       )
     }
 
+    /// The name reserved for "answer the user directly". A tool may not take it;
+    /// `Transcript.ToolDefinition` names come from `Tool.name`, so the collision is
+    /// possible in principle and silently breaks routing if it happens.
+    static let noToolSentinel = "none"
+
     private static func toolInstructions(_ tools: [Transcript.ToolDefinition]) -> String {
       var lines = ["You can call tools to help answer the user. Available tools:"]
       for tool in tools {
@@ -322,25 +354,53 @@
         lines.append("- \(tool.name): \(tool.description). arguments schema: \(params)")
       }
       lines.append(
-        "To call a tool, reply with ONLY this JSON and nothing else: "
-          + "{\"tool_call\": {\"name\": \"<tool name>\", \"arguments\": { ... }}}. "
-          + "If no tool is needed, answer the user directly.")
+        "Reply with ONLY this JSON and nothing else: "
+          + "{\"tool\": \"<tool name or \(noToolSentinel)>\", \"answer\": \"<your reply>\"}. "
+          + "Pick a tool when one of them can supply something you do not know, and leave "
+          + "\"answer\" empty in that case — you will be asked for the arguments next. "
+          + "Use \"\(noToolSentinel)\" when you can already answer, and put the reply in "
+          + "\"answer\".")
       return lines.joined(separator: "\n")
     }
 
-    private static func parseToolCall(from text: String, tools: [Transcript.ToolDefinition])
-      -> (name: String, arguments: String)?
+    /// The router grammar: one enum of tool names plus the sentinel, and the reply
+    /// to use when the sentinel is picked. Deliberately limited to
+    /// object/properties/required/enum/string — the subset every JSON-Schema
+    /// grammar compiler supports.
+    static func routeSchema(_ tools: [Transcript.ToolDefinition]) -> [String: Any] {
+      var names = [noToolSentinel]
+      names.append(contentsOf: tools.map { $0.name }.filter { $0 != noToolSentinel })
+      return [
+        "type": "object",
+        "properties": [
+          "tool": ["type": "string", "enum": names],
+          "answer": ["type": "string"],
+        ],
+        "required": ["tool", "answer"],
+      ]
+    }
+
+    private static func argumentsRequest(for tool: Transcript.ToolDefinition) -> String {
+      let params = (try? encodeSchema(tool.parameters)) ?? "{}"
+      return "Now output ONLY the arguments for \"\(tool.name)\" as a JSON object "
+        + "matching this schema, and nothing else:\n\(params)"
+    }
+
+    /// Read the router's answer. A model that ignores the grammar (or a runtime
+    /// without constrained decoding) still lands here, so an unparseable reply is
+    /// treated as "no tool" and its raw text becomes the answer.
+    static func parseRoute(from text: String, tools: [Transcript.ToolDefinition])
+      -> (tool: Transcript.ToolDefinition?, answer: String)
     {
       guard let json = extractJSONObject(from: text),
         let data = json.data(using: .utf8),
-        let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        let call = obj["tool_call"] as? [String: Any],
-        let name = call["name"] as? String,
-        tools.contains(where: { $0.name == name })
-      else { return nil }
-      let args = call["arguments"] ?? [String: Any]()
-      let argsData = (try? JSONSerialization.data(withJSONObject: args)) ?? Data("{}".utf8)
-      return (name, String(data: argsData, encoding: .utf8) ?? "{}")
+        let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+      else { return (nil, text) }
+      let answer = (obj["answer"] as? String) ?? ""
+      guard let name = obj["tool"] as? String, name != noToolSentinel,
+        let tool = tools.first(where: { $0.name == name })
+      else { return (nil, answer) }
+      return (tool, answer)
     }
 
     private static func text(of segments: [Transcript.Segment]) -> String {

--- a/swift/apple_fm/LiteRTLanguageModel.swift
+++ b/swift/apple_fm/LiteRTLanguageModel.swift
@@ -47,6 +47,20 @@
 
   // MARK: - Model
 
+  /// How the tool list is written into the conversation config — and therefore
+  /// into the prompt: the bundle's chat template `tojson`s each entry verbatim,
+  /// so this string is exactly what the model reads, character for character.
+  @available(iOS 27.0, macOS 27.0, *)
+  public enum ToolListStyle: Sendable, Hashable {
+    /// `{"type": "function", "function": {…}}` per tool — the OpenAI envelope
+    /// most instruct models (Qwen, Gemma) saw in training. The default.
+    case openAIFunctions
+    /// `{"name", "description", "parameters"}` per tool — the LFM2 family's
+    /// trained format. The envelope is ~30 prompt characters per tool that
+    /// these models never saw.
+    case bare
+  }
+
   /// A LiteRT-LM model exposed as an Apple Foundation Models backend.
   @available(iOS 27.0, macOS 27.0, *)
   public struct LiteRTLanguageModel: LanguageModel {
@@ -55,6 +69,16 @@
     public let capabilities: LanguageModelCapabilities
     public let executorConfiguration: LiteRTLMExecutor.Configuration
     public let visualTokenBudget: Int32?
+    public let toolListStyle: ToolListStyle
+    /// Cap on invisible reasoning, in tokens. Hybrid-thinking bundles (LFM2.5)
+    /// declare a `<think>…</think>` channel in their metadata, and the runtime
+    /// diverts everything inside it away from the stream. Without a budget
+    /// nothing forces the block closed: a turn where the model decides to think
+    /// generates unseen at decode speed — 25–40 s on a phone — and can end with
+    /// an empty message, which Foundation Models reports as "Session ended
+    /// without producing a response". The budget forces `</think>` after this
+    /// many thinking tokens. Zero or negative disables the cap.
+    public let thinkingTokenBudget: Int
 
     /// Build from an `EngineConfig` (the primary initializer). The whole config is
     /// carried through to the engine verbatim — including `cacheDir`, `loraRank`,
@@ -64,8 +88,18 @@
     ///   - engineConfig: How to build the LiteRT engine.
     ///   - visualTokenBudget: Per-image visual-token cap (an `ExperimentalFlags`
     ///     value, not part of `EngineConfig`); nil = engine default.
-    public init(engineConfig: EngineConfig, visualTokenBudget: Int32? = nil) {
+    ///   - toolListStyle: How tool definitions are written into the prompt;
+    ///     pick to match what the bundle's model saw in training.
+    ///   - thinkingTokenBudget: Max invisible reasoning tokens per turn before
+    ///     `</think>` is forced; ≤ 0 leaves thinking unbounded.
+    public init(
+      engineConfig: EngineConfig, visualTokenBudget: Int32? = nil,
+      toolListStyle: ToolListStyle = .openAIFunctions,
+      thinkingTokenBudget: Int = 256
+    ) {
       self.visualTokenBudget = visualTokenBudget
+      self.toolListStyle = toolListStyle
+      self.thinkingTokenBudget = thinkingTokenBudget
       self.executorConfiguration = LiteRTLMExecutor.Configuration(
         engineConfig: engineConfig)
       let capabilities: [LanguageModelCapabilities.Capability] = {
@@ -90,6 +124,10 @@
     ///   - maxTokens: KV/context budget (nil = model/engine default).
     ///   - cacheDir: Where the engine writes its cache files (nil = the app's Caches
     ///     directory).
+    ///   - toolListStyle: How tool definitions are written into the prompt;
+    ///     pick to match what the bundle's model saw in training.
+    ///   - thinkingTokenBudget: Max invisible reasoning tokens per turn before
+    ///     `</think>` is forced; ≤ 0 leaves thinking unbounded.
     /// - Throws: `LiteRTLMError` if `maxTokens` is less than or equal to 0.
     public init(
       modelPath: String,
@@ -98,7 +136,9 @@
       audioBackend: Backend? = nil,
       visualTokenBudget: Int32? = nil,
       maxTokens: Int? = 2048,
-      cacheDir: String? = nil
+      cacheDir: String? = nil,
+      toolListStyle: ToolListStyle = .openAIFunctions,
+      thinkingTokenBudget: Int = 256
     ) throws {
       let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
       self.init(
@@ -106,7 +146,9 @@
           modelPath: modelPath, backend: backend,
           visionBackend: visionBackend, audioBackend: audioBackend,
           maxNumTokens: maxTokens, cacheDir: cacheDir ?? caches?.path),
-        visualTokenBudget: visualTokenBudget)
+        visualTokenBudget: visualTokenBudget,
+        toolListStyle: toolListStyle,
+        thinkingTokenBudget: thinkingTokenBudget)
     }
 
     /// Release every cached LiteRT engine built for FM sessions, freeing their
@@ -141,7 +183,11 @@
       }
     }
 
+    /// How many user/tool exchanges before the current one are replayed.
+    static let historyExchanges = 1
+
     private let engine: LazyEngine
+    private let cache = ConversationCache()
 
     public init(configuration: Configuration) throws {
       // Share one engine per configuration across executors. FM builds a new
@@ -166,59 +212,121 @@
       // constrain decoding to the schema (llguidance), which makes it impossible
       // for the output to deviate from it.
       //
-      // Tools take the same treatment, in two constrained steps: first the model
-      // picks a tool name (or "none") out of an enum, then — only if it picked one
-      // — it fills that tool's own parameter schema. A single combined schema
-      // would need `anyOf` to switch the argument shape on the chosen name; the
-      // split keeps every grammar to enum/object/required, which is the part of
-      // JSON Schema that is safe to assume, and it constrains the arguments
-      // rather than hoping the model spells them right.
+      // Tools are different: they go to the engine as definitions and the model
+      // calls them in its own trained format, which this executor parses back
+      // (`parseNativeToolCall`).
       let tools = request.enabledToolDefinitions
       let schemaJSON = request.schema.flatMap { try? Self.encodeSchema($0) }
       let plan = try Self.plan(from: request.transcript, schemaJSON: schemaJSON, tools: tools)
       let responseFormat = schemaJSON.flatMap { try? ResponseFormat.json(schema: $0) }
-      let routeFormat = tools.isEmpty ? nil : try? ResponseFormat.json(schema: Self.routeSchema(tools))
-
       let structured = schemaJSON != nil || !tools.isEmpty
-      let conversation = try await engine.createConversation(
-        with: ConversationConfig(
+      let offerTools = !tools.isEmpty && !plan.respondingToTool
+
+      // LFM2.5 has its own tool-call format — `<|tool_call_start|>[name(args)]
+      // <|tool_call_end|>` — and LiteRT-LM parses it. The JSON router this used
+      // to impose fought that: under a grammar for the router's shape the model
+      // could not emit the tokens it wanted and produced nothing at all, and
+      // without one it emitted its native call, which the router could not read.
+      // So the tools go to the engine as tool definitions, and the model answers
+      // in the form it was trained for.
+      // Reused across turns. Building one costs the tokenisation and KV setup of
+      // the whole prefix — measured at 15-19s a turn on a phone, against 0.4-1.4s
+      // of actual generation — and it was being paid twice per beat. Tools stay
+      // attached for every turn; the tool-output message already tells the model
+      // to answer rather than call again.
+      let resumeKey = plan.systemText
+      var reusable: Conversation?
+      if let reused = cache.take(for: resumeKey, consumed: plan.triggerIndex) {
+        // A conversation is reused only while its KV has room for another
+        // turn. Every fix that makes turns *succeed* also makes the KV grow
+        // monotonically — the first fully green demo run died on beat 5 with
+        // "remaining capacity: 4". A windowed rebuild costs one prefill;
+        // an exhausted conversation costs the beat.
+        let capacity = model.executorConfiguration.engineConfig.maxNumTokens ?? 2048
+        let used = (try? reused.getTokenCount()) ?? 0
+        if used > capacity - Self.turnTokenHeadroom {
+          LiteRTFMTrace.timing("cache DROP, kv \(used)/\(capacity)")
+        } else {
+          reusable = reused
+        }
+      }
+      let conversation: Conversation
+      if let reused = reusable {
+        LiteRTFMTrace.timing(
+          "cache HIT, prompt \(plan.promptText.count) chars, history \(plan.history.count)")
+        conversation = reused
+      } else {
+        LiteRTFMTrace.timing(
+          "cache MISS, prompt \(plan.promptText.count) chars, history \(plan.history.count)"
+            + ", system \(plan.systemText.count) chars")
+        conversation = try await Self.build(
+        ConversationConfig(
           systemMessage: plan.systemMessage,
           initialMessages: plan.history,
           samplerConfig: Self.sampler(for: request.generationOptions, structured: structured),
-          enableResponseFormat: responseFormat != nil || routeFormat != nil,
-          visualTokenBudget: model.visualTokenBudget))
+          // Cap invisible reasoning. Never `enableThinking: false` here: the
+          // runtime only installs the budget constraint when thinking is
+          // enabled — disabling it removes the cap and leaves the model free
+          // to think, unseen and unbounded (this template ignores the
+          // `enable_thinking` flag).
+          thinkingConfig: model.thinkingTokenBudget > 0
+            ? ThinkingConfig(enableThinking: true, thinkingTokenBudget: model.thinkingTokenBudget)
+            : nil,
+          // Off: FM runs the tools and re-invokes this executor with the result.
+          // Letting the runtime run them too would execute everything twice.
+          automaticToolCalling: false,
+          // Not offered on the turn that answers a tool result. FM re-invokes
+          // the executor after every tool, and a model still holding the menu
+          // orders again: translate was called four times in a row off one OCR
+          // result. A chained call the model writes anyway is honored below,
+          // behind a per-question round limit.
+          toolsJsonOverride: offerTools
+            ? Self.toolsJson(tools, style: model.toolListStyle) : nil,
+          enableResponseFormat: responseFormat != nil,
+          visualTokenBudget: model.visualTokenBudget),
+          on: engine)
+      }
+      defer { cache.keep(conversation, for: resumeKey, consumed: plan.triggerIndex) }
 
-      if !tools.isEmpty {
-        var routeText = ""
-        for try await chunk in conversation.sendMessageStream(
-          plan.prompt, responseFormat: routeFormat)
-        {
-          routeText += chunk.toString
+      if offerTools {
+        LiteRTFMTrace.emit("\u{00B7} \(tools.count) tools offered\n")
+        // Streamed, unconstrained. The non-streaming call took the app down on
+        // the first turn; and since this bundle's metadata does not declare the
+        // tool-call delimiters, the runtime hands the markers through as text
+        // either way — so they are read here.
+        var replyText = ""
+        var thought = ""
+        let sent = Date()
+        var firstToken: Date?
+        for try await chunk in conversation.sendMessageStream(plan.prompt) {
+          let piece = chunk.toString
+          if firstToken == nil, !piece.isEmpty { firstToken = Date() }
+          replyText += piece
+          thought += chunk.channels.values.joined()
+          LiteRTFMTrace.emit(piece)
         }
-        let route = Self.parseRoute(from: routeText, tools: tools)
-
-        if let tool = route.tool {
-          // The chosen tool's parameter schema is the grammar for this second
-          // pass, so the arguments cannot come back malformed or under-filled.
-          let argsFormat = (try? Self.encodeSchema(tool.parameters)).flatMap {
-            try? ResponseFormat.json(schema: $0)
-          }
-          var argsText = ""
-          for try await chunk in conversation.sendMessageStream(
-            Message(Self.argumentsRequest(for: tool), role: .user), responseFormat: argsFormat)
-          {
-            argsText += chunk.toString
-          }
-          let arguments = Self.extractJSONObject(from: argsText) ?? "{}"
+        let done = Date()
+        if !thought.isEmpty { LiteRTFMTrace.emit("\n[think] \(thought)\n") }
+        LiteRTFMTrace.timing(
+          "call turn: ttft \(String(format: "%.1f", (firstToken ?? done).timeIntervalSince(sent)))s"
+            + ", decode \(String(format: "%.1f", done.timeIntervalSince(firstToken ?? done)))s"
+            + ", \(replyText.count) chars, \(thought.count) thought")
+        // The visible text first; a model that spent its whole turn inside the
+        // think block sometimes leaves the call — or the answer — in there.
+        let native = Self.parseNativeToolCall(replyText) ?? Self.parseNativeToolCall(thought)
+        if let call = native {
+          let arguments = call.arguments
+          LiteRTFMTrace.emit("\(call.name) \(arguments)\n")
           await channel.send(
             .toolCalls(
               action: .toolCall(
-                id: UUID().uuidString, name: tool.name,
+                id: UUID().uuidString, name: call.name,
                 action: .appendArguments(arguments, tokenCount: arguments.count))))
         } else {
-          // "none": the same constrained pass already carries the reply, so a
-          // plain chat turn still costs one generation.
-          let answer = route.answer.isEmpty ? routeText : route.answer
+          var answer = Self.visibleAnswer(replyText)
+          if answer.isEmpty {
+            answer = thought.trimmingCharacters(in: .whitespacesAndNewlines)
+          }
           await channel.send(.response(action: .appendText(answer, tokenCount: answer.count)))
         }
       } else if schemaJSON != nil {
@@ -230,12 +338,70 @@
         }
         let json = Self.extractJSONObject(from: full) ?? full
         await channel.send(.response(action: .appendText(json, tokenCount: json.count)))
+      } else if !tools.isEmpty {
+        // The turn that answers a tool result. Buffered rather than streamed:
+        // the model sometimes answers with another call — "Open CAFE LA in
+        // Apple Maps" routed through `search_places` first, then `open_in_maps`
+        // — and a call has to be forwarded whole, not scrolled onto the screen
+        // as text, which is what a streamed answer turn did to that beat.
+        var replyText = ""
+        var thought = ""
+        let sent = Date()
+        var firstToken: Date?
+        for try await chunk in conversation.sendMessageStream(plan.prompt) {
+          let piece = chunk.toString
+          if firstToken == nil, !piece.isEmpty { firstToken = Date() }
+          replyText += piece
+          thought += chunk.channels.values.joined()
+          LiteRTFMTrace.emit(piece)
+        }
+        let done = Date()
+        if !thought.isEmpty { LiteRTFMTrace.emit("\n[think] \(thought)\n") }
+        LiteRTFMTrace.timing(
+          "answer turn: ttft \(String(format: "%.1f", (firstToken ?? done).timeIntervalSince(sent)))s"
+            + ", decode \(String(format: "%.1f", done.timeIntervalSince(firstToken ?? done)))s"
+            + ", \(replyText.count) chars, \(thought.count) thought, round \(plan.toolRounds)")
+        let native = Self.parseNativeToolCall(replyText) ?? Self.parseNativeToolCall(thought)
+        if let call = native, plan.toolRounds < Self.maxToolRoundsPerQuestion {
+          LiteRTFMTrace.emit("\(call.name) \(call.arguments)\n")
+          await channel.send(
+            .toolCalls(
+              action: .toolCall(
+                id: UUID().uuidString, name: call.name,
+                action: .appendArguments(call.arguments, tokenCount: call.arguments.count))))
+        } else {
+          // A reply that is only call markers (rounds exhausted) or nothing at
+          // all (the model never left its think block) falls back to the tool's
+          // own words. Something is always sent: an executor that returns
+          // without sending is an FM error — "Session ended without producing a
+          // response" — that poisons the transcript for every beat after it.
+          var answer = Self.visibleAnswer(replyText)
+          if native != nil || answer.isEmpty {
+            answer = plan.toolResult ?? answer
+          }
+          await channel.send(.response(action: .appendText(answer, tokenCount: answer.count)))
+        }
       } else {
+        // Plain chat, no tools anywhere: stream as it generates.
+        let sent = Date()
+        var firstToken: Date?
+        var total = 0
         for try await chunk in conversation.sendMessageStream(plan.prompt) {
           let delta = chunk.toString
           if !delta.isEmpty {
+            if firstToken == nil { firstToken = Date() }
+            total += delta.count
+            LiteRTFMTrace.emit(delta)
             await channel.send(.response(action: .appendText(delta, tokenCount: 1)))
           }
+        }
+        let done = Date()
+        LiteRTFMTrace.timing(
+          "chat turn: ttft \(String(format: "%.1f", (firstToken ?? done).timeIntervalSince(sent)))s"
+            + ", decode \(String(format: "%.1f", done.timeIntervalSince(firstToken ?? done)))s"
+            + ", \(total) chars")
+        if total == 0 {
+          await channel.send(.response(action: .appendText("", tokenCount: 0)))
         }
       }
     }
@@ -276,7 +442,38 @@
       let systemMessage: Message?
       let history: [Message]
       let prompt: Message
+      /// True when the turn was triggered by a tool's output rather than by the
+      /// user. FM re-invokes the executor after a tool returns so the model can
+      /// answer *from* the result — offering it the tool menu again is how a
+      /// small model ends up calling the same tool forever.
+      let respondingToTool: Bool
+      /// The system message as text, used as the cache key.
+      let systemText: String
+      /// Where the trigger sits, and where every input sits. A conversation may
+      /// resume only if it has already been fed each input before the trigger.
+      let triggerIndex: Int
+      let inputIndices: [Int]
+      /// The trigger's text, repeated into the arguments pass. Without it a
+      /// small model fills the schema from the tool's own description and
+      /// inverts booleans — "turn the flashlight on" became {"on": false}.
+      let promptText: String
+      /// The trimmed result text when the trigger is a tool's output — the
+      /// fallback answer for a turn whose generation comes back empty.
+      let toolResult: String?
+      /// How many tools have already run for the current user question. Bounds
+      /// chained calls: one follow-up is what "open the shop you found" needs,
+      /// unbounded is translate called four times in a row.
+      let toolRounds: Int
     }
+
+    /// Chained tool calls allowed per user question before the model is made
+    /// to answer with what it has.
+    static let maxToolRoundsPerQuestion = 2
+
+    /// KV room a turn needs: its prompt, its generation, and the thinking
+    /// budget. A cached conversation closer to the ceiling than this is
+    /// dropped and rebuilt from the windowed transcript.
+    static let turnTokenHeadroom = 384
 
     /// Split the FM transcript into a system message, prior turns (history), and
     /// the message to generate from. The generation trigger is the last `.prompt`
@@ -296,13 +493,58 @@
         throw LiteRTFMError.noPrompt
       }
 
+      let triggeredByTool: Bool
+      if case .toolOutput = entries[triggerIndex] { triggeredByTool = true } else {
+        triggeredByTool = false
+      }
+
+      // Every entry the model did not itself produce is an input. A resumed
+      // conversation may only skip entries it produced, so the cache needs to
+      // know where the inputs are.
+      let inputIndices = entries.indices.filter { i in
+        switch entries[i] {
+        case .prompt, .toolOutput: return true
+        default: return false
+        }
+      }
+
+      var triggerText = ""
+      var triggerToolResult: String?
+      // Tool outputs since the question being answered: every entry after the
+      // last user prompt at or before the trigger.
+      let lastPromptIndex =
+        entries[...triggerIndex].lastIndex(where: {
+          if case .prompt = $0 { return true } else { return false }
+        }) ?? entries.startIndex
+      let toolRounds = entries[lastPromptIndex...triggerIndex].filter {
+        if case .toolOutput = $0 { return true } else { return false }
+      }.count
       var systemText: [String] = []
-      if !tools.isEmpty { systemText.append(toolInstructions(tools)) }
+      // Only the exchanges near the trigger are sent. A `LanguageModelSession`
+      // keeps the whole conversation, which is right for the session and wrong
+      // for a phone: by the sixth turn the prefill is mostly history and the
+      // model returns nothing at all. Two exchanges is enough for "read that
+      // out loud" to know what "that" is.
+      let inputPositions = entries.indices.filter { i in
+        switch entries[i] {
+        case .prompt, .toolOutput: return true
+        default: return false
+        }
+      }
+      let keepFrom = inputPositions.suffix(Self.historyExchanges + 1).first ?? 0
+      // No tool protocol in the system message any more. The engine is given the
+      // tool definitions and the model answers in its own trained format; a
+      // second, contradictory convention in the prompt is what made it reply
+      // {"tool": "schedule_notification", …} instead of calling anything.
       var history: [Message] = []
       var trigger: Message?
 
       for (i, entry) in entries.enumerated() {
         let isTrigger = (i == triggerIndex)
+        // Instructions always; everything else only inside the window.
+        if !isTrigger && i < keepFrom {
+          if case .instructions = entry {} else { continue }
+        }
         switch entry {
         case .instructions(let instructions):
           systemText.append(text(of: instructions.segments))
@@ -315,17 +557,48 @@
                   + "Output valid JSON and nothing else:\n\(schemaJSON)"))
           }
           let message = Message(contents: c, role: .user)
-          if isTrigger { trigger = message } else { history.append(message) }
+          if isTrigger {
+            trigger = message
+            triggerText = text(of: p.segments)
+          } else {
+            history.append(message)
+          }
         case .response(let r):
           history.append(Message(contents: [.text(text(of: r.segments))], role: .model))
         case .toolOutput(let output):
-          let result = text(of: output.segments)
+          // Trimmed before it goes back to the model. A tool may legitimately
+          // return a lot — an OCR pass returned a whole café menu — and every
+          // turn after that one carries it in the history until the context is
+          // gone and generations come back empty. The host still shows the full
+          // text; the model only needs enough to answer from.
+          var result = text(of: output.segments)
+          if result.count > 240 {
+            result = String(result.prefix(240)) + "…"
+          }
+          // "Do not call another tool" is a bias, not a rule: the executor
+          // honors a chained call the model writes anyway, up to
+          // `maxToolRoundsPerQuestion`.
           let message = Message(
-            "Tool \"\(output.toolName)\" returned: \(result)\nUse this result to answer the user.",
+            "Tool \"\(output.toolName)\" returned: \(result)\n"
+              + "Answer the user in one short sentence using that result. "
+              + "Do not output JSON and do not call another tool.",
             role: .user)
-          if isTrigger { trigger = message } else { history.append(message) }
-        case .toolCalls:
-          history.append(Message("[the assistant called a tool]", role: .model))
+          if isTrigger {
+            trigger = message
+            triggerToolResult = result
+          } else {
+            history.append(message)
+          }
+        case .toolCalls(let calls):
+          // Written back in the model's own call format. A prose placeholder
+          // here — "[the assistant called a tool]" — was being imitated: shown
+          // that a call looks like a sentence about calling, the model wrote
+          // sentences about calling instead of calling.
+          let rendered = calls.map { call -> String in
+            let arguments = Self.pythonicArguments(call.arguments)
+            return "<|tool_call_start|>[\(call.toolName)(\(arguments))]<|tool_call_end|>"
+          }.joined()
+          history.append(Message(rendered, role: .model))
         case .reasoning:
           break
         @unknown default:
@@ -338,8 +611,208 @@
       return Plan(
         systemMessage: system.isEmpty ? nil : Message(system, role: .system),
         history: history,
-        prompt: trigger!  // guaranteed by triggerIndex
+        prompt: trigger!,  // guaranteed by triggerIndex
+        respondingToTool: triggeredByTool,
+        systemText: system,
+        triggerIndex: triggerIndex,
+        inputIndices: inputIndices,
+        promptText: triggerText,
+        toolResult: triggerToolResult,
+        toolRounds: toolRounds
       )
+    }
+
+    /// `<|tool_call_start|>[name(key=value, key='text')]<|tool_call_end|>` —
+    /// LFM2.5's own call format, as it comes back when the runtime has not
+    /// split it out. The value syntax is Python-ish: bare numbers and booleans,
+    /// single or double quoted strings.
+    static func parseNativeToolCall(_ text: String) -> (name: String, arguments: String)? {
+      guard let open = text.range(of: "<|tool_call_start|>"),
+        let close = text.range(of: "<|tool_call_end|>", range: open.upperBound..<text.endIndex)
+      else { return nil }
+      var body = String(text[open.upperBound..<close.lowerBound])
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      if body.hasPrefix("[") { body.removeFirst() }
+      if body.hasSuffix("]") { body.removeLast() }
+      guard let parenthesis = body.firstIndex(of: "(") , body.hasSuffix(")") else {
+        let name = body.trimmingCharacters(in: .whitespaces)
+        return name.isEmpty ? nil : (name, "{}")
+      }
+      let name = String(body[body.startIndex..<parenthesis]).trimmingCharacters(in: .whitespaces)
+      let inside = String(body[body.index(after: parenthesis)..<body.index(before: body.endIndex)])
+      var arguments: [String: Any] = [:]
+      for pair in splitTopLevel(inside) {
+        guard let equals = pair.firstIndex(of: "=") else { continue }
+        let key = String(pair[pair.startIndex..<equals]).trimmingCharacters(in: .whitespaces)
+        var value = String(pair[pair.index(after: equals)...]).trimmingCharacters(in: .whitespaces)
+        if (value.hasPrefix("'") && value.hasSuffix("'"))
+          || (value.hasPrefix("\"") && value.hasSuffix("\"")), value.count >= 2
+        {
+          value.removeFirst()
+          value.removeLast()
+          arguments[key] = value
+        } else if let number = Int(value) {
+          arguments[key] = number
+        } else if let number = Double(value) {
+          arguments[key] = number
+        } else if value == "true" || value == "false" {
+          arguments[key] = value == "true"
+        } else {
+          arguments[key] = value
+        }
+      }
+      return (name, argumentsJSON(arguments))
+    }
+
+    /// Split on commas that are not inside quotes, so a quoted value may contain
+    /// one.
+    private static func splitTopLevel(_ text: String) -> [String] {
+      var out: [String] = []
+      var current = ""
+      var quote: Character?
+      for character in text {
+        if let open = quote {
+          current.append(character)
+          if character == open { quote = nil }
+        } else if character == "'" || character == "\"" {
+          quote = character
+          current.append(character)
+        } else if character == "," {
+          out.append(current)
+          current = ""
+        } else {
+          current.append(character)
+        }
+      }
+      if !current.trimmingCharacters(in: .whitespaces).isEmpty { out.append(current) }
+      return out
+    }
+
+    /// Arguments back in the form the model writes them: `key='text', n=5`.
+    static func pythonicArguments(_ content: GeneratedContent) -> String {
+      guard let data = String(describing: content).data(using: .utf8),
+        let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+      else { return "" }
+      return object.keys.sorted().compactMap { key -> String? in
+        switch object[key] {
+        case let value as String: return "\(key)='\(value)'"
+        case let value as Bool: return "\(key)=\(value)"
+        case let value as NSNumber: return "\(key)=\(value)"
+        default: return nil
+        }
+      }.joined(separator: ", ")
+    }
+
+    static func build(_ config: ConversationConfig, on engine: Engine) async throws
+      -> Conversation
+    {
+      try await engine.createConversation(with: config)
+    }
+
+    /// The part of a reply that is meant for the user. The thinking budget
+    /// force-closes `</think>` after N tokens, but the model does not know
+    /// that: it keeps reasoning into the visible stream and closes the block
+    /// again itself — so text before the *last* closer is thought that leaked,
+    /// not answer ("…short answer as requested.</think>You are near CAFE LA…").
+    static func visibleAnswer(_ text: String) -> String {
+      let tail = text.range(of: "</think>", options: .backwards).map { text[$0.upperBound...] }
+      var answer = String(tail ?? text[...])
+      if answer.hasPrefix("<think>") { answer.removeFirst("<think>".count) }
+      return answer.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// FM's tool definitions as the string the model will read. The runtime
+    /// parses this as a JSON array and hands each entry to the chat template
+    /// verbatim (`tojson`), so every character here is prompt tokens — on the
+    /// demo phone the tool list alone was 84% of each turn's prefill.
+    static func toolsJson(
+      _ tools: [Transcript.ToolDefinition], style: ToolListStyle = .openAIFunctions
+    ) -> String {
+      let entries: [String] = tools.map { tool in
+        var function: [String: Any] = ["name": tool.name, "description": tool.description]
+        if let encoded = try? encodeSchema(tool.parameters),
+          let data = encoded.data(using: .utf8),
+          let raw = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+          let schema = prunedSchema(raw) as? [String: Any],
+          let properties = schema["properties"] as? [String: Any], !properties.isEmpty
+        {
+          function["parameters"] = schema
+        }
+        switch style {
+        case .openAIFunctions:
+          return canonicalJSON(["type": "function", "function": function])
+        case .bare:
+          return canonicalJSON(function)
+        }
+      }
+      return "[" + entries.joined(separator: ", ") + "]"
+    }
+
+    /// Strip what the model cannot use: FM's `title`/`x-order` bookkeeping (at
+    /// every level, not just the top), `additionalProperties`, and empty
+    /// `required` arrays — none of which appear in any model's trained tool
+    /// format.
+    private static func prunedSchema(_ value: Any) -> Any {
+      if let array = value as? [Any] { return array.map(prunedSchema) }
+      guard var object = value as? [String: Any] else { return value }
+      object.removeValue(forKey: "title")
+      object.removeValue(forKey: "x-order")
+      object.removeValue(forKey: "additionalProperties")
+      if (object["required"] as? [Any])?.isEmpty == true {
+        object.removeValue(forKey: "required")
+      }
+      for (key, inner) in object { object[key] = prunedSchema(inner) }
+      return object
+    }
+
+    /// The key order trained tool formats use: `name` before `description`
+    /// before `parameters`; inside a schema, `type` before `properties` before
+    /// `required`. Keys not listed sort alphabetically after these.
+    private static let toolKeyOrder = [
+      "type", "function", "name", "description", "parameters", "properties", "enum", "required",
+      "items",
+    ]
+
+    /// Serialize with `toolKeyOrder`. `JSONSerialization` randomizes dictionary
+    /// order per process, which would make the prompt differ run to run; sorted
+    /// keys would put `description` before `name` and `type` last, which no
+    /// model saw in training.
+    private static func canonicalJSON(_ value: Any) -> String {
+      switch value {
+      case let object as [String: Any]:
+        let keys = object.keys.sorted { a, b in
+          let ia = toolKeyOrder.firstIndex(of: a) ?? toolKeyOrder.count
+          let ib = toolKeyOrder.firstIndex(of: b) ?? toolKeyOrder.count
+          return ia == ib ? a < b : ia < ib
+        }
+        return "{"
+          + keys.map { "\(quotedJSON($0)): \(canonicalJSON(object[$0]!))" }.joined(separator: ", ")
+          + "}"
+      case let array as [Any]:
+        return "[" + array.map(canonicalJSON).joined(separator: ", ") + "]"
+      case let string as String:
+        return quotedJSON(string)
+      case let number as NSNumber:
+        if CFGetTypeID(number) == CFBooleanGetTypeID() { return number.boolValue ? "true" : "false" }
+        return "\(number)"
+      default:
+        return "null"
+      }
+    }
+
+    private static func quotedJSON(_ string: String) -> String {
+      guard let data = try? JSONSerialization.data(withJSONObject: [string]),
+        let text = String(data: data, encoding: .utf8)
+      else { return "\"\(string)\"" }
+      return String(text.dropFirst().dropLast())
+    }
+
+    static func argumentsJSON(_ arguments: [String: Any]) -> String {
+      guard JSONSerialization.isValidJSONObject(arguments),
+        let data = try? JSONSerialization.data(withJSONObject: arguments),
+        let json = String(data: data, encoding: .utf8)
+      else { return "{}" }
+      return json
     }
 
     /// The name reserved for "answer the user directly". A tool may not take it;
@@ -348,10 +821,13 @@
     static let noToolSentinel = "none"
 
     private static func toolInstructions(_ tools: [Transcript.ToolDefinition]) -> String {
+      // Names and descriptions only. The argument schemas belong to the second
+      // pass, which asks for one tool's arguments against that tool's schema —
+      // putting all of them here triples the prompt and, with a few dozen tools,
+      // buries the one line that decides the choice.
       var lines = ["You can call tools to help answer the user. Available tools:"]
       for tool in tools {
-        let params = (try? encodeSchema(tool.parameters)) ?? "{}"
-        lines.append("- \(tool.name): \(tool.description). arguments schema: \(params)")
+        lines.append("- \(tool.name): \(tool.description)")
       }
       lines.append(
         "Reply with ONLY this JSON and nothing else: "
@@ -380,10 +856,20 @@
       ]
     }
 
-    private static func argumentsRequest(for tool: Transcript.ToolDefinition) -> String {
-      let params = (try? encodeSchema(tool.parameters)) ?? "{}"
-      return "Now output ONLY the arguments for \"\(tool.name)\" as a JSON object "
-        + "matching this schema, and nothing else:\n\(params)"
+    private static func argumentsRequest(
+      for tool: Transcript.ToolDefinition, asked: String
+    ) -> String {
+      // No schema in the prompt. The grammar already forces the shape, and the
+      // schema's own `description` strings were the most tempting text in view:
+      // asked to fill `text`, the model copied "The text to speak. The language
+      // specification indicates a BCP-47 voice language…" into it. What is left
+      // in front of the model is the request, which is what it should copy.
+      var lines = ["The request was: \(asked)"]
+      if asked.isEmpty { lines = [] }
+      lines.append(
+        "Reply with the JSON arguments for \"\(tool.name)\". Copy values out of the request "
+          + "exactly as written, in their original script. Nothing else.")
+      return lines.joined(separator: "\n")
     }
 
     /// Read the router's answer. A model that ignores the grammar (or a runtime
@@ -468,17 +954,6 @@
             break
           }
           out.append(.imageData(png))
-        case .custom(let custom):
-          switch custom {
-          case let audio as LiteRTAudioSegment:
-            out.append(.audioData(audio.content.data))
-          case let video as LiteRTVideoSegment:
-            out.append(contentsOf: video.content.frames.map { Content.imageData($0) })
-          default:
-            logger.warning(
-              "LiteRT-LM: Unsupported custom segment type \(String(describing: type(of: custom))). Segment ignored."
-            )
-          }
         case .structure:
           break
         @unknown default:
@@ -486,6 +961,65 @@
         }
       }
       return out.isEmpty ? [.text("")] : out
+    }
+  }
+
+  /// Holds a conversation between turns so its prefix is prefilled once.
+  ///
+  /// Reusable while the prefix is the same string and this turn continues where
+  /// the last one stopped. Anything else — a new session, a different tool set,
+  /// a branched transcript — misses, and a fresh conversation is built.
+  @available(iOS 27.0, macOS 27.0, *)
+  final class ConversationCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var conversation: Conversation?
+    private var key: String?
+    private var consumed = -1
+
+    func take(for key: String, consumed trigger: Int) -> Conversation? {
+      lock.lock()
+      defer { lock.unlock() }
+      guard self.key == key, trigger > consumed, let held = conversation else { return nil }
+      conversation = nil
+      return held
+    }
+
+    func keep(_ conversation: Conversation, for key: String, consumed trigger: Int) {
+      lock.lock()
+      self.conversation = conversation
+      self.key = key
+      self.consumed = trigger
+      lock.unlock()
+    }
+  }
+
+  /// Raw model output, as it arrives, for a host that wants to show it.
+  ///
+  /// The tool path cannot stream into the FM channel — a half-written tool call
+  /// is not an answer — so without this a caller sees nothing until the whole
+  /// turn is done. Debug/demo aid: set it to nil to pay nothing.
+  @available(iOS 27.0, macOS 27.0, *)
+  public enum LiteRTFMTrace {
+    nonisolated(unsafe) public static var onChunk: (@Sendable (String) -> Void)?
+    /// Decode tokens per second for the pass that just finished, so a host can
+    /// show the real speed rather than a spinner. One stream chunk is one token.
+    nonisolated(unsafe) public static var onRate: (@Sendable (Double) -> Void)?
+
+    static func emit(_ piece: String) {
+      guard !piece.isEmpty, let onChunk else { return }
+      onChunk(piece)
+    }
+
+    /// Where a turn's seconds went, for a host that wants to show or log it.
+    nonisolated(unsafe) public static var onTiming: (@Sendable (String) -> Void)?
+
+    static func timing(_ line: String) {
+      onTiming?(line)
+    }
+
+    static func rate(tokens: Int, seconds: Double) {
+      guard seconds > 0, tokens > 0, let onRate else { return }
+      onRate(Double(tokens) / seconds)
     }
   }
 

--- a/swift/apple_fm/LiteRTLanguageModel.swift
+++ b/swift/apple_fm/LiteRTLanguageModel.swift
@@ -729,17 +729,34 @@
           value.removeFirst()
           value.removeLast()
           arguments[key] = value
-        } else if let number = Int(value) {
+          continue
+        }
+        // An unquoted value never ends in a parenthesis; a stray one is the
+        // call's own closer that a doubled `))` left behind.
+        while value.hasSuffix(")") { value.removeLast() }
+        if let number = Int(value) {
           arguments[key] = number
         } else if let number = Double(value) {
           arguments[key] = number
-        } else if value == "true" || value == "false" {
-          arguments[key] = value == "true"
+        } else if let flag = booleanLiteral(value) {
+          arguments[key] = flag
         } else {
           arguments[key] = value
         }
       }
       return (name, argumentsJSON(arguments))
+    }
+
+    /// `true`/`false` as JSON writes them and `True`/`False` as Python does:
+    /// the call format is Python-ish, and on device the 1.2B wrote
+    /// `set_torch(on=True)` — passed through as the string "True", FM failed
+    /// the call with "GeneratedContent does not contain Bool".
+    private static func booleanLiteral(_ text: String) -> Bool? {
+      switch text.lowercased() {
+      case "true": return true
+      case "false": return false
+      default: return nil
+      }
     }
 
     /// Split on commas that are not inside quotes, so a quoted value may contain

--- a/swift/apple_fm/LiteRTLanguageModel.swift
+++ b/swift/apple_fm/LiteRTLanguageModel.swift
@@ -61,6 +61,22 @@
     case bare
   }
 
+  /// How a `respond(generating:)` turn is held to its schema.
+  @available(iOS 27.0, macOS 27.0, *)
+  public enum GuidedGeneration: Sendable, Hashable {
+    /// The engine constrains decoding to the schema (LiteRT-LM `ResponseFormat`,
+    /// llguidance): every token is checked against the grammar, so the output
+    /// cannot deviate from it. The schema is also written into the prompt
+    /// unless the caller's `ContextOptions.includeSchemaInPrompt` is false.
+    /// The default.
+    case constrained
+    /// The schema is only written into the prompt (again subject to
+    /// `includeSchemaInPrompt`); the output is whatever the model writes. For a
+    /// runtime built without constrained decoding, and for measuring what the
+    /// constraint buys.
+    case promptOnly
+  }
+
   /// A LiteRT-LM model exposed as an Apple Foundation Models backend.
   @available(iOS 27.0, macOS 27.0, *)
   public struct LiteRTLanguageModel: LanguageModel {
@@ -70,6 +86,9 @@
     public let executorConfiguration: LiteRTLMExecutor.Configuration
     public let visualTokenBudget: Int32?
     public let toolListStyle: ToolListStyle
+    /// Whether a schema is enforced by the engine or only asked for in the
+    /// prompt. See `GuidedGeneration`.
+    public let guidedGeneration: GuidedGeneration
     /// Cap on invisible reasoning, in tokens. Hybrid-thinking bundles (LFM2.5)
     /// declare a `<think>…</think>` channel in their metadata, and the runtime
     /// diverts everything inside it away from the stream. Without a budget
@@ -92,14 +111,18 @@
     ///     pick to match what the bundle's model saw in training.
     ///   - thinkingTokenBudget: Max invisible reasoning tokens per turn before
     ///     `</think>` is forced; ≤ 0 leaves thinking unbounded.
+    ///   - guidedGeneration: Whether a schema is enforced by the engine
+    ///     (`.constrained`, the default) or only written into the prompt.
     public init(
       engineConfig: EngineConfig, visualTokenBudget: Int32? = nil,
       toolListStyle: ToolListStyle = .openAIFunctions,
-      thinkingTokenBudget: Int = 256
+      thinkingTokenBudget: Int = 256,
+      guidedGeneration: GuidedGeneration = .constrained
     ) {
       self.visualTokenBudget = visualTokenBudget
       self.toolListStyle = toolListStyle
       self.thinkingTokenBudget = thinkingTokenBudget
+      self.guidedGeneration = guidedGeneration
       self.executorConfiguration = LiteRTLMExecutor.Configuration(
         engineConfig: engineConfig)
       let capabilities: [LanguageModelCapabilities.Capability] = {
@@ -128,6 +151,8 @@
     ///     pick to match what the bundle's model saw in training.
     ///   - thinkingTokenBudget: Max invisible reasoning tokens per turn before
     ///     `</think>` is forced; ≤ 0 leaves thinking unbounded.
+    ///   - guidedGeneration: Whether a schema is enforced by the engine
+    ///     (`.constrained`, the default) or only written into the prompt.
     /// - Throws: `LiteRTLMError` if `maxTokens` is less than or equal to 0.
     public init(
       modelPath: String,
@@ -138,7 +163,8 @@
       maxTokens: Int? = 2048,
       cacheDir: String? = nil,
       toolListStyle: ToolListStyle = .openAIFunctions,
-      thinkingTokenBudget: Int = 256
+      thinkingTokenBudget: Int = 256,
+      guidedGeneration: GuidedGeneration = .constrained
     ) throws {
       let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
       self.init(
@@ -148,7 +174,8 @@
           maxNumTokens: maxTokens, cacheDir: cacheDir ?? caches?.path),
         visualTokenBudget: visualTokenBudget,
         toolListStyle: toolListStyle,
-        thinkingTokenBudget: thinkingTokenBudget)
+        thinkingTokenBudget: thinkingTokenBudget,
+        guidedGeneration: guidedGeneration)
     }
 
     /// Release every cached LiteRT engine built for FM sessions, freeing their
@@ -186,6 +213,14 @@
     /// How many user/tool exchanges before the current one are replayed.
     static let historyExchanges = 1
 
+    /// What a cached conversation was built for.
+    enum ConversationKind: String {
+      /// No tool menu; accepts a response format. Plain chat and guided turns.
+      case open
+      /// A tool session's conversation, tools in the preface.
+      case tooled
+    }
+
     private let engine: LazyEngine
     private let cache = ConversationCache()
 
@@ -207,20 +242,30 @@
       streamingInto channel: LanguageModelExecutorGenerationChannel
     ) async throws {
       let engine = try await self.engine.ready()
-      // Guided generation: if the request carries a schema, encode it to JSON,
-      // steer the model via the prompt (schema-in-prompt), and additionally
-      // constrain decoding to the schema (llguidance), which makes it impossible
-      // for the output to deviate from it.
+      // Guided generation: a request that carries a schema is a structured-
+      // output contract. The schema is written into the prompt unless the
+      // caller's `ContextOptions.includeSchemaInPrompt` says not to (FM's own
+      // knob, for a schema the instructions already describe), and under
+      // `.constrained` the engine also constrains decoding to it
+      // (`ResponseFormat`, llguidance), so the output cannot deviate from it.
+      // No tool menu on such a turn: the structure is the answer.
       //
       // Tools are different: they go to the engine as definitions and the model
       // calls them in its own trained format, which this executor parses back
       // (`parseNativeToolCall`).
       let tools = request.enabledToolDefinitions
-      let schemaJSON = request.schema.flatMap { try? Self.encodeSchema($0) }
-      let plan = try Self.plan(from: request.transcript, schemaJSON: schemaJSON, tools: tools)
-      let responseFormat = schemaJSON.flatMap { try? ResponseFormat.json(schema: $0) }
-      let structured = schemaJSON != nil || !tools.isEmpty
-      let offerTools = !tools.isEmpty && !plan.respondingToTool
+      let schemaJSON = try request.schema.map { try Self.encodeSchema($0) }
+      let guided = schemaJSON != nil
+      let schemaInPrompt = request.contextOptions.includeSchemaInPrompt ?? true
+      let constrained = guided && model.guidedGeneration == .constrained
+      let plan = try Self.plan(
+        from: request.transcript, schemaJSON: schemaInPrompt ? schemaJSON : nil,
+        guided: guided, constrained: constrained, tools: tools)
+      let responseFormat =
+        try constrained
+        ? schemaJSON.map { try ResponseFormat.json(schema: Self.engineSchema($0)) } : nil
+      let structured = guided || !tools.isEmpty
+      let offerTools = !tools.isEmpty && !plan.respondingToTool && !guided
 
       // LFM2.5 has its own tool-call format — `<|tool_call_start|>[name(args)]
       // <|tool_call_end|>` — and LiteRT-LM parses it. The JSON router this used
@@ -234,7 +279,12 @@
       // of actual generation — and it was being paid twice per beat. Tools stay
       // attached for every turn; the tool-output message already tells the model
       // to answer rather than call again.
-      let resumeKey = plan.systemText
+      // Keyed by the system text and the conversation's kind. A guided turn
+      // needs a conversation that accepts a response format and carries no
+      // tool menu; a tool session's conversation is neither, so the two kinds
+      // never share one.
+      let kind: ConversationKind = guided || tools.isEmpty ? .open : .tooled
+      let resumeKey = plan.systemText + "\u{1F}" + kind.rawValue
       var reusable: Conversation?
       if let reused = cache.take(for: resumeKey, consumed: plan.triggerIndex) {
         // A conversation is reused only while its KV has room for another
@@ -282,13 +332,51 @@
           // behind a per-question round limit.
           toolsJsonOverride: offerTools
             ? Self.toolsJson(tools, style: model.toolListStyle) : nil,
-          enableResponseFormat: responseFormat != nil,
+          // On for every open conversation, not only the turn that carries a
+          // schema: the conversation is reused across turns, and one built
+          // without it refuses a later guided turn (`responseFormatNotEnabled`).
+          // Tooled conversations keep it off — with it on, the runtime derives a
+          // tool-call grammar from the preface where the model's data processor
+          // has one, and the native-format tool path here was measured without.
+          enableResponseFormat: kind == .open && model.guidedGeneration == .constrained,
           visualTokenBudget: model.visualTokenBudget),
           on: engine)
       }
       defer { cache.keep(conversation, for: resumeKey, consumed: plan.triggerIndex) }
 
-      if offerTools {
+      if guided {
+        // Buffered: FM parses the structure out of the text it is handed, and
+        // a half-written object is not one. Under the constraint the thinking
+        // budget is switched off for this turn: the runtime wraps the caller's
+        // constraint in its thinking-budget constraint, and on a hybrid bundle
+        // that pairing failed every guided turn (llguidance panic at token 0);
+        // the grammar itself keeps `<think>` out, so nothing is lost.
+        var full = ""
+        let sent = Date()
+        var firstToken: Date?
+        for try await chunk in conversation.sendMessageStream(
+          plan.prompt,
+          thinkingConfig: constrained
+            ? ThinkingConfig(enableThinking: false, thinkingTokenBudget: 0) : nil,
+          responseFormat: responseFormat)
+        {
+          let piece = chunk.toString
+          if firstToken == nil, !piece.isEmpty { firstToken = Date() }
+          full += piece
+          LiteRTFMTrace.emit(piece)
+        }
+        let done = Date()
+        LiteRTFMTrace.timing(
+          "guided turn: ttft \(String(format: "%.1f", (firstToken ?? done).timeIntervalSince(sent)))s"
+            + ", decode \(String(format: "%.1f", done.timeIntervalSince(firstToken ?? done)))s"
+            + ", \(full.count) chars, \(constrained ? "constrained" : "prompt only")"
+            + ", schema in prompt \(schemaInPrompt)")
+        // Under the constraint the text is the object. Without one the model
+        // may wrap it in prose or a code fence; the first balanced object is
+        // taken.
+        let json = Self.extractJSONObject(from: full) ?? full
+        await channel.send(.response(action: .appendText(json, tokenCount: json.count)))
+      } else if offerTools {
         LiteRTFMTrace.emit("\u{00B7} \(tools.count) tools offered\n")
         // Streamed, unconstrained. The non-streaming call took the app down on
         // the first turn; and since this bundle's metadata does not declare the
@@ -329,15 +417,6 @@
           }
           await channel.send(.response(action: .appendText(answer, tokenCount: answer.count)))
         }
-      } else if schemaJSON != nil {
-        var full = ""
-        for try await chunk in conversation.sendMessageStream(
-          plan.prompt, responseFormat: responseFormat)
-        {
-          full += chunk.toString
-        }
-        let json = Self.extractJSONObject(from: full) ?? full
-        await channel.send(.response(action: .appendText(json, tokenCount: json.count)))
       } else if !tools.isEmpty {
         // The turn that answers a tool result. Buffered rather than streamed:
         // the model sometimes answers with another call — "Open CAFE LA in
@@ -438,7 +517,7 @@
 
     // MARK: Transcript → LiteRT messages
 
-    private struct Plan {
+    struct Plan {
       let systemMessage: Message?
       let history: [Message]
       let prompt: Message
@@ -447,15 +526,12 @@
       /// answer *from* the result — offering it the tool menu again is how a
       /// small model ends up calling the same tool forever.
       let respondingToTool: Bool
-      /// The system message as text, used as the cache key.
+      /// The system message as text, the cache key's first half.
       let systemText: String
-      /// Where the trigger sits, and where every input sits. A conversation may
-      /// resume only if it has already been fed each input before the trigger.
+      /// Where the trigger sits. A conversation may resume only if it has
+      /// already been fed every input before the trigger.
       let triggerIndex: Int
-      let inputIndices: [Int]
-      /// The trigger's text, repeated into the arguments pass. Without it a
-      /// small model fills the schema from the tool's own description and
-      /// inverts booleans — "turn the flashlight on" became {"on": false}.
+      /// The trigger's text, for the timing trace.
       let promptText: String
       /// The trimmed result text when the trigger is a tool's output — the
       /// fallback answer for a turn whose generation comes back empty.
@@ -478,8 +554,15 @@
     /// Split the FM transcript into a system message, prior turns (history), and
     /// the message to generate from. The generation trigger is the last `.prompt`
     /// OR (in a tool round-trip) the last `.toolOutput`.
-    private static func plan(
-      from transcript: Transcript, schemaJSON: String?, tools: [Transcript.ToolDefinition]
+    ///
+    /// `schemaJSON` is the schema to write into the trigger, nil when none is
+    /// wanted there; `guided` says whether the turn expects a structure at all,
+    /// a separate question when the caller keeps the schema out of the prompt;
+    /// `constrained` says the engine will hold the output to the schema, which
+    /// changes how much of it the prompt has to carry.
+    static func plan(
+      from transcript: Transcript, schemaJSON: String?, guided: Bool = false,
+      constrained: Bool = false, tools: [Transcript.ToolDefinition]
     ) throws -> Plan {
       let entries = Array(transcript)
       guard
@@ -496,16 +579,6 @@
       let triggeredByTool: Bool
       if case .toolOutput = entries[triggerIndex] { triggeredByTool = true } else {
         triggeredByTool = false
-      }
-
-      // Every entry the model did not itself produce is an input. A resumed
-      // conversation may only skip entries it produced, so the cache needs to
-      // know where the inputs are.
-      let inputIndices = entries.indices.filter { i in
-        switch entries[i] {
-        case .prompt, .toolOutput: return true
-        default: return false
-        }
       }
 
       var triggerText = ""
@@ -551,10 +624,7 @@
         case .prompt(let p):
           var c = contents(of: p.segments)
           if isTrigger, let schemaJSON, !schemaJSON.isEmpty {
-            c.append(
-              .text(
-                "\n\nRespond with ONLY a JSON object that conforms to this JSON schema. "
-                  + "Output valid JSON and nothing else:\n\(schemaJSON)"))
+            c.append(.text("\n\n" + schemaHint(schemaJSON, constrained: constrained)))
           }
           let message = Message(contents: c, role: .user)
           if isTrigger {
@@ -577,12 +647,21 @@
           }
           // "Do not call another tool" is a bias, not a rule: the executor
           // honors a chained call the model writes anyway, up to
-          // `maxToolRoundsPerQuestion`.
+          // `maxToolRoundsPerQuestion`. A guided turn asks for the structure
+          // instead — "do not output JSON" would be the one wrong thing to say.
+          let instruction: String
+          if isTrigger && guided {
+            let hint =
+              schemaJSON.map { schemaHint($0, constrained: constrained) }
+              ?? "Respond with ONLY a JSON object. Output valid JSON and nothing else."
+            instruction = "Using that result, " + hint.prefix(1).lowercased() + hint.dropFirst()
+          } else {
+            instruction =
+              "Answer the user in one short sentence using that result. "
+              + "Do not output JSON and do not call another tool."
+          }
           let message = Message(
-            "Tool \"\(output.toolName)\" returned: \(result)\n"
-              + "Answer the user in one short sentence using that result. "
-              + "Do not output JSON and do not call another tool.",
-            role: .user)
+            "Tool \"\(output.toolName)\" returned: \(result)\n" + instruction, role: .user)
           if isTrigger {
             trigger = message
             triggerToolResult = result
@@ -615,7 +694,6 @@
         respondingToTool: triggeredByTool,
         systemText: system,
         triggerIndex: triggerIndex,
-        inputIndices: inputIndices,
         promptText: triggerText,
         toolResult: triggerToolResult,
         toolRounds: toolRounds
@@ -815,84 +893,123 @@
       return json
     }
 
-    /// The name reserved for "answer the user directly". A tool may not take it;
-    /// `Transcript.ToolDefinition` names come from `Tool.name`, so the collision is
-    /// possible in principle and silently breaks routing if it happens.
-    static let noToolSentinel = "none"
-
-    private static func toolInstructions(_ tools: [Transcript.ToolDefinition]) -> String {
-      // Names and descriptions only. The argument schemas belong to the second
-      // pass, which asks for one tool's arguments against that tool's schema —
-      // putting all of them here triples the prompt and, with a few dozen tools,
-      // buries the one line that decides the choice.
-      var lines = ["You can call tools to help answer the user. Available tools:"]
-      for tool in tools {
-        lines.append("- \(tool.name): \(tool.description)")
-      }
-      lines.append(
-        "Reply with ONLY this JSON and nothing else: "
-          + "{\"tool\": \"<tool name or \(noToolSentinel)>\", \"answer\": \"<your reply>\"}. "
-          + "Pick a tool when one of them can supply something you do not know, and leave "
-          + "\"answer\" empty in that case — you will be asked for the arguments next. "
-          + "Use \"\(noToolSentinel)\" when you can already answer, and put the reply in "
-          + "\"answer\".")
-      return lines.joined(separator: "\n")
-    }
-
-    /// The router grammar: one enum of tool names plus the sentinel, and the reply
-    /// to use when the sentinel is picked. Deliberately limited to
-    /// object/properties/required/enum/string — the subset every JSON-Schema
-    /// grammar compiler supports.
-    static func routeSchema(_ tools: [Transcript.ToolDefinition]) -> [String: Any] {
-      var names = [noToolSentinel]
-      names.append(contentsOf: tools.map { $0.name }.filter { $0 != noToolSentinel })
-      return [
-        "type": "object",
-        "properties": [
-          "tool": ["type": "string", "enum": names],
-          "answer": ["type": "string"],
-        ],
-        "required": ["tool", "answer"],
-      ]
-    }
-
-    private static func argumentsRequest(
-      for tool: Transcript.ToolDefinition, asked: String
-    ) -> String {
-      // No schema in the prompt. The grammar already forces the shape, and the
-      // schema's own `description` strings were the most tempting text in view:
-      // asked to fill `text`, the model copied "The text to speak. The language
-      // specification indicates a BCP-47 voice language…" into it. What is left
-      // in front of the model is the request, which is what it should copy.
-      var lines = ["The request was: \(asked)"]
-      if asked.isEmpty { lines = [] }
-      lines.append(
-        "Reply with the JSON arguments for \"\(tool.name)\". Copy values out of the request "
-          + "exactly as written, in their original script. Nothing else.")
-      return lines.joined(separator: "\n")
-    }
-
-    /// Read the router's answer. A model that ignores the grammar (or a runtime
-    /// without constrained decoding) still lands here, so an unparseable reply is
-    /// treated as "no tool" and its raw text becomes the answer.
-    static func parseRoute(from text: String, tools: [Transcript.ToolDefinition])
-      -> (tool: Transcript.ToolDefinition?, answer: String)
-    {
-      guard let json = extractJSONObject(from: text),
-        let data = json.data(using: .utf8),
-        let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-      else { return (nil, text) }
-      let answer = (obj["answer"] as? String) ?? ""
-      guard let name = obj["tool"] as? String, name != noToolSentinel,
-        let tool = tools.first(where: { $0.name == name })
-      else { return (nil, answer) }
-      return (tool, answer)
-    }
-
     private static func text(of segments: [Transcript.Segment]) -> String {
       segments.compactMap { segment in
         if case .text(let t) = segment { return t.content } else { return nil }
       }.joined(separator: " ")
+    }
+
+    /// The schema-in-prompt text for the trigger. The prompt carries what the
+    /// engine does not: without a grammar, a field list — name, type, enum
+    /// values, description — so the model knows the shape; under a grammar,
+    /// the key names alone, in order. Never the raw JSON schema: shown that,
+    /// a small model echoes it, and under a grammar the echo comes back as a
+    /// well-formed object full of the schema's own words ("title",
+    /// "PrimaryColors") — and a field list under a grammar did the same in
+    /// miniature, `": "` where a value should be. A schema without properties
+    /// (a bare type) is shown as it is.
+    static func schemaHint(_ schemaJSON: String, constrained: Bool = false) -> String {
+      guard let data = schemaJSON.data(using: .utf8),
+        let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+        root["properties"] is [String: Any]
+      else {
+        return "Respond with ONLY a JSON value that conforms to this JSON schema:\n"
+          + "\(schemaJSON)\nOutput valid JSON and nothing else."
+      }
+      if constrained {
+        return "Respond with ONLY a JSON object with exactly these keys, in this order: "
+          + propertyOrder(root).joined(separator: ", ") + ". Output valid JSON and nothing else."
+      }
+      var lines = ["Respond with ONLY a JSON object with these fields, in this order:"]
+      lines.append(contentsOf: fieldLines(root, indent: "- ") ?? [])
+      lines.append("Output valid JSON and nothing else.")
+      return lines.joined(separator: "\n")
+    }
+
+    /// One line per property — `- name (type[, one of: …][, optional]):
+    /// description` — in Foundation Models' declared order, nested objects
+    /// indented beneath their field.
+    private static func fieldLines(_ schema: [String: Any], indent: String) -> [String]? {
+      guard let properties = schema["properties"] as? [String: Any] else { return nil }
+      let required = Set(schema["required"] as? [String] ?? [])
+      var lines: [String] = []
+      for name in propertyOrder(schema) {
+        guard let property = properties[name] as? [String: Any] else { continue }
+        var kind = typeName(property)
+        if let values = property["enum"] as? [Any] {
+          kind += ", one of: " + values.map { "\($0)" }.joined(separator: ", ")
+        }
+        if !required.contains(name) { kind += ", optional" }
+        var line = "\(indent)\(name) (\(kind))"
+        if let description = property["description"] as? String, !description.isEmpty {
+          line += ": \(description)"
+        }
+        lines.append(line)
+        let nested =
+          (property["type"] as? String) == "array" ? property["items"] as? [String: Any] : property
+        if let nested, let inner = fieldLines(nested, indent: "  " + indent) {
+          lines.append(contentsOf: inner)
+        }
+      }
+      return lines
+    }
+
+    private static func typeName(_ property: [String: Any]) -> String {
+      if let type = property["type"] as? String {
+        if type == "array", let items = property["items"] as? [String: Any] {
+          return "array of \(typeName(items))"
+        }
+        return type
+      }
+      return property["anyOf"] != nil ? "one of the listed forms" : "value"
+    }
+
+    /// Property names in generation order: FM's `x-order` first, anything it
+    /// does not name alphabetically after.
+    private static func propertyOrder(_ schema: [String: Any]) -> [String] {
+      let properties = schema["properties"] as? [String: Any] ?? [:]
+      let declared = (schema["x-order"] as? [String] ?? []).filter { properties[$0] != nil }
+      return declared + properties.keys.filter { !declared.contains($0) }.sorted()
+    }
+
+    /// The schema as the engine's grammar compiler should see it: properties
+    /// in Foundation Models' declared generation order (`x-order`), which the
+    /// sorted-keys encoding loses and llguidance would replace with
+    /// alphabetical — the model was then made to fill `extras` before it had
+    /// read what was ordered. `title` and `x-order` are dropped on the way:
+    /// they are FM bookkeeping, not schema. Everything else stays sorted, so
+    /// the text is still the same run to run.
+    static func engineSchema(_ schemaJSON: String) -> String {
+      guard let data = schemaJSON.data(using: .utf8),
+        let root = try? JSONSerialization.jsonObject(with: data)
+      else { return schemaJSON }
+      return orderedJSON(root)
+    }
+
+    private static func orderedJSON(_ value: Any) -> String {
+      switch value {
+      case let object as [String: Any]:
+        let keys = object.keys.filter { $0 != "title" && $0 != "x-order" }.sorted()
+        let members = keys.map { key -> String in
+          if key == "properties", let properties = object[key] as? [String: Any] {
+            let body = propertyOrder(object).map {
+              "\(quotedJSON($0)):\(orderedJSON(properties[$0]!))"
+            }.joined(separator: ",")
+            return "\(quotedJSON(key)):{\(body)}"
+          }
+          return "\(quotedJSON(key)):\(orderedJSON(object[key]!))"
+        }
+        return "{" + members.joined(separator: ",") + "}"
+      case let array as [Any]:
+        return "[" + array.map(orderedJSON).joined(separator: ",") + "]"
+      case let string as String:
+        return quotedJSON(string)
+      case let number as NSNumber:
+        if CFGetTypeID(number) == CFBooleanGetTypeID() { return number.boolValue ? "true" : "false" }
+        return "\(number)"
+      default:
+        return "null"
+      }
     }
 
     /// Encode a schema to canonical JSON. `.sortedKeys` matters: dictionary key

--- a/swift/apple_fm/LiteRTSegments.swift
+++ b/swift/apple_fm/LiteRTSegments.swift
@@ -16,70 +16,27 @@
 // This implementation was originally authored by @john-rocky and ported
 // from the open-source repository: https://github.com/john-rocky/swift-litert-lm/tree/main
 //
-// Audio and video through the Foundation Models API.
+// Audio and video through the Foundation Models API — currently unavailable.
 //
-// Apple's FM transcript has built-in text and *image* segments, but no audio or
-// video. The custom-segment hook (`Transcript.CustomSegment`) lets a backend
-// carry arbitrary modalities through the FM API. These segments feed audio and
-// sampled video frames into LiteRT's encoders.
+// This file held `LiteRTAudioSegment` and `LiteRTVideoSegment`, two
+// `Transcript.CustomSegment` conformances that carried audio bytes and video
+// frames into a prompt, since FM's transcript has built-in text and image
+// segments but nothing for either.
 //
-//   let answer = try await session.respond {
-//     LiteRTAudioSegment(data: wavBytes)
-//     "Transcribe the spoken words."
-//   }
+// The iOS 27 beta-5 SDK removed the hook. `Transcript.Segment` is now
+// text / structure / attachment only, `Transcript.Attachment` is a closed enum
+// whose sole case is `.image`, and `Transcript.CustomSegment` no longer exists —
+// so a third-party segment type has no representation at all, and the executor's
+// matching `.custom` branch went with it.
+//
+// The engine side is untouched: `Content.audioData` and multi-image prompts
+// still work through the LiteRTLM API directly. What is gone is the route in
+// through a `LanguageModelSession` prompt. If a later SDK reopens custom
+// segments, restore both halves from the history of this file.
 
 #if canImport(FoundationModels) && compiler(>=6.4)
 
   import Foundation
   import FoundationModels
-
-  /// A Foundation Models prompt segment carrying audio for a LiteRT backend.
-  ///
-  /// `Transcript.CustomSegment` supplies `promptRepresentation`, `description`, and
-  /// equality for free; we only provide `id` + `content`. Include it in a prompt
-  /// via the `@PromptBuilder` overloads of `respond` / `streamResponse`.
-  @available(iOS 27.0, macOS 27.0, *)
-  public struct LiteRTAudioSegment: Transcript.CustomSegment {
-    public struct Content: Codable, Equatable, Sendable {
-      public var data: Data
-      public init(data: Data) { self.data = data }
-    }
-
-    public let id: String
-    public var content: Content
-
-    /// - Parameters:
-    ///   - data: Raw audio bytes (WAV / supported container).
-    ///   - id: Stable identifier for the segment.
-    public init(data: Data, id: String = UUID().uuidString) {
-      self.id = id
-      self.content = Content(data: data)
-    }
-
-    /// Convenience for audio already on disk.
-    public init(fileURL: URL, id: String = UUID().uuidString) throws {
-      self.id = id
-      self.content = Content(data: try Data(contentsOf: fileURL))
-    }
-  }
-
-  /// A Foundation Models prompt segment carrying sampled video frames (image bytes,
-  /// in temporal order). The executor feeds them to the model as a sequence of
-  /// images.
-  @available(iOS 27.0, macOS 27.0, *)
-  public struct LiteRTVideoSegment: Transcript.CustomSegment {
-    public struct Content: Codable, Equatable, Sendable {
-      public var frames: [Data]
-      public init(frames: [Data]) { self.frames = frames }
-    }
-
-    public let id: String
-    public var content: Content
-
-    public init(frames: [Data], id: String = UUID().uuidString) {
-      self.id = id
-      self.content = Content(frames: frames)
-    }
-  }
 
 #endif


### PR DESCRIPTION
Rebased on 8bb1e1c6 (main as of 2026-09-10). The first slice of this PR, deterministic schema encoding plus engine-level constrained decoding for guided generation, landed via #3264 — thank you for importing it.
Remaining here: 4 commits on top of that, all in the Foundation Models adapter (`swift/apple_fm`, plus the `ConversationConfig` / `Package.swift` hooks they need): constrained tool calling (9e881191); bounded thinking, trained-format tool lists, survivable answer turns (191fd0b8); guided generation honoring `includeSchemaInPrompt`, with the engine's schema in declared order (7165a2f1); Python booleans and a stray closer in native tool calls (e5766e73). The description below is the original one for the first slice.

---

This is the guided-generation fix I proposed over email after the v0.15.0 verification (thank you again for the release — and for the quick green light to send it as a normal PR). Summary: guided generation in the Apple Foundation Models adapter occasionally failed with the model echoing the JSON schema back instead of filling it. The defect is in my original prompt-based design, not in the runtime. Two changes: encode the schema deterministically, and constrain decoding to the schema with the v0.15.0 `ResponseFormat` (llguidance) API so the output cannot deviate from it. Verified end-to-end on macOS against the v0.15.0 release binaries; a CI-safe unit test is included. Whatever form is easiest for you to import works for me — happy to reshape or split.

Details, if useful:

**Root cause.** `encodeSchema` used a plain `JSONEncoder`, and Foundation randomizes dictionary key order per process — so the schema JSON, which is embedded verbatim in the prompt, differed between identical runs. Two encodings of the same schema from my probe runs (the inner dictionaries vary even within one process):

```
run A: {"title":"SortedKeysProbe","type":"object","properties":{"apple":{"description":"apple","type":"string"},"mango":{"type":"string","description":"mango"}, ...
run B: {"required":["zebra","apple","mango"],"title":"SortedKeysProbe","type":"object","properties":{"mango":{"description":"mango","type":"string"}, ...
```

With the prompt varying run to run, a fraction of runs steered the model into echoing the schema instead of filling it. Measured with gemma-4-E2B-it on the GPU backend, ten separate process invocations each (separate processes are what expose the flake, since key order is per-process): unpatched adapter 6/10 guided requests succeed, the failures being `GeneratedContent does not contain a property 'colors'` — the schema echo. This matches the 3/5 I reported from the v0.15.0 release verification.

**Fix.**
- `encodeSchema` now uses `.sortedKeys`: the schema JSON is canonical, so the prompt is stable across runs (this also stabilizes the tool-instruction prompts built from tool parameter schemas). The function changed from `private` to internal for the new test.
- Guided requests now also pass the schema as `ResponseFormat.json` to the conversation (`enableResponseFormat` on the config), so decoding is constrained by llguidance and the output cannot deviate from the schema even in the worst case. The schema stays in the prompt as before: the constraint guarantees the shape, the prompt tells the model what to fill.

**Verification** (macOS, the v0.15.0 release xcframeworks pinned by `Package.swift`, gemma-4-E2B-it):
- Same-day A/B with the same methodology: patched adapter 10/10 guided requests across ten separate process invocations on GPU (unpatched: 6/10), plus 10/10 within-process on GPU and 1/1 on the CPU backend.
- Constraint engagement verified mechanically via the core Swift API (the same `sendMessage`/`ResponseFormat` plumbing the adapter now uses): a regex constraint that contradicts the prompt ("Reply with the single word YES." + pattern `NO`) yields `NO`, and a JSON-schema constraint against a haiku prompt yields a schema-conforming object — so llguidance is doing the enforcement against the release binaries, not the prompt.
- `respond(to:)` and tool calling: unchanged, pass.
- `AdapterTests`: all 8 tests pass including the new `testSchemaEncodingIsDeterministicAndSorted`, which asserts the encoding is repeatable and canonically ordered; it needs no model file, like the rest of AdapterTests.

