### PR TITLE
Derive Qwen3-TTS MTP cache length from model mask shape

### DIFF
--- a/omni/tts/qwen3_tts/qwen3_acoustic_predictor_stage.cc
+++ b/omni/tts/qwen3_tts/qwen3_acoustic_predictor_stage.cc
@@ -194,6 +194,26 @@ Qwen3AcousticPredictorStage::Create(
       stage->mtp_model_->CreateOutputBuffer(stage->mtp_signature_name_,
                                             stage->mtp_logits_output_name_));
 
+  // Derive MTP cache length from the exported model's mask tensor.
+  LITERT_ASSIGN_OR_RETURN(
+      auto mtp_mask_type,
+      stage->mtp_mask_buf_.TensorType());
+  
+  auto mtp_mask_dims = mtp_mask_type.Layout().Dimensions();
+  
+  if (mtp_mask_dims.empty()) {
+    return absl::InvalidArgumentError(
+        "Invalid MTP attention mask dimensions.");
+  }
+  
+  // Expected: [1, 1, 1, cache_len]
+  if (mtp_mask_dims.size() < 1) {
+    return absl::InvalidArgumentError(
+        "MTP attention mask has no dimensions.");
+  }
+  
+  stage->mtp_cache_len_ = mtp_mask_dims.back();
+
   for (const auto& k_name : stage->mtp_k_input_names_) {
     LITERT_ASSIGN_OR_RETURN(auto buf0, stage->mtp_model_->CreateInputBuffer(
                                            stage->mtp_signature_name_, k_name));


### PR DESCRIPTION
This change derives the Qwen3 MTP cache length from the exported model's attention mask tensor instead of relying on a hard-coded value.

The MTP mask is expected to have the form [1, 1, 1, cache_len], so its last dimension is used to initialize mtp_cache_len_.

This makes the stage compatible with exported MTP models that use a different cache length, while preserving the existing behavior for models exposing the expected mask shape.