### PR TITLE
Force GPU BUFFER storage on non-Apple platforms

### DIFF
--- a/runtime/executor/llm_executor_settings_utils.cc
+++ b/runtime/executor/llm_executor_settings_utils.cc
@@ -93,6 +93,10 @@ absl::StatusOr<litert::Options> CreateCompilationOptions(
           advanced_settings.gpu_enable_metal_residency_set);
 #else   // !__APPLE__
       gpu_compilation_options.SetPreferTextureWeights(true);
+      // Force BUFFER storage to avoid ml_drift IMAGE_2D vs linear-read
+      // incompatibility on Adreno/OpenCL when GPU composite ops are used.
+      gpu_compilation_options.SetBufferStorageType(
+          GpuOptions::BufferStorageType::kBuffer);
 #endif  // !__APPLE__
 
       auto model_scoped_file =


### PR DESCRIPTION
Avoids ml_drift IMAGE_2D vs linear-read incompatibility on Adreno/OpenCL when GPU composite ops are used.

Incorrect Full Call Chain
[Your op / composite]                             ← Uses tensor.Read(idx) with a single argument
    ↓
ml_drift/common/merge_nodes.cc:633                ← Merges this op into a fused node
    ↓
ml_drift/common/gpu_model_builder.cc:3792         ← Determines the storage type for the fused tensor
    ↓ Based on the SetPreferTextureWeights(true) hint, TEXTURE_2D is selected
    ↓
tflite/delegates/gpu/common/task/tensor_desc.cc:496  ← Storage type and access pattern are incompatible
    → "Read selector with single argument can be used only with linear
       storage types (BUFFER or IMAGE_BUFFER)"

The actual bug is in ml_drift: merge_nodes allows an op that requires 1D linear reads to be fused with a tensor that is subsequently assigned TEXTURE_2D storage. The incompatibility is only detected later during validation.

tensor_desc.cc:496 is merely the rejection point, not the root cause of the bug.

Trigger Condition

The upper layer uses SetPreferTextureWeights(true) to tell ml_drift that texture storage is preferred. When the model contains certain ops (such as GPU composite ops) that explicitly require linear reads, this leads to the above incompatibility.