### PR TITLE
Fix JS build on corporate-proxy networks and WASM/TS version skew

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -1,0 +1,15 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+spec_dist/
+
+# Downloaded WASM artifacts
+packages/core/wasm/
+
+# Turborepo
+.turbo/
+
+# Logs
+npm-debug.log*

--- a/js/apps/chat/package.json
+++ b/js/apps/chat/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@litert-lm/core": "0.12.1",
+    "@litert-lm/core": "0.15.0",
     "highlight.js": "^11.11.1",
     "katex": "^0.16.28",
     "lit": "^3.3.3",

--- a/js/apps/model_tester/package.json
+++ b/js/apps/model_tester/package.json
@@ -10,7 +10,7 @@
     "model-tester": "serve.js"
   },
   "scripts": {
-    "copy-wasm": "mkdirp dist && cp -r `node -e \"console.log(path.join(require.resolve('@litert-lm/core/package.json'), '../wasm'))\"` dist/",
+    "copy-wasm": "node scripts/copy-wasm.js",
     "copy-static-files": "cp -r static dist && npm run copy-wasm",
     "dev": "rimraf dist && npm run copy-static-files && node scripts/devserver.js",
     "build": "rimraf dist && npm run copy-static-files  && esbuild --bundle --target=es2020 --outfile=dist/bundle.js --sourcemap src/index.ts"
@@ -25,13 +25,12 @@
   "description": "",
   "dependencies": {
     "@lit/task": "^1.0.2",
-    "@litert-lm/core": "^0.12.1",
+    "@litert-lm/core": "^0.15.0",
     "@material/web": "^2.3.0",
     "argparse": "^2.0.1",
-    "esbuild": "^0.23.0",
+    "esbuild": "^0.28.2",
     "express": "^5.1.0",
     "lit": "^3.2.1",
-    "mkdirp": "^3.0.1",
     "open": "^10.2.0",
     "rimraf": "^6.0.1"
   },

--- a/js/apps/model_tester/scripts/copy-wasm.js
+++ b/js/apps/model_tester/scripts/copy-wasm.js
@@ -1,0 +1,27 @@
+// Copyright 2026 The ODML Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const coreDir = path.dirname(require.resolve('@litert-lm/core/package.json'));
+const wasmSrcDir = path.resolve(coreDir, 'wasm');
+const wasmDstDir = path.resolve('dist', 'wasm');
+
+fs.mkdirSync(wasmDstDir, { recursive: true });
+for (const file of fs.readdirSync(wasmSrcDir)) {
+  fs.copyFileSync(path.resolve(wasmSrcDir, file), path.resolve(wasmDstDir, file));
+}

--- a/js/packages/core/package.json
+++ b/js/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litert-lm/core",
-  "version": "0.12.1",
+  "version": "0.15.0",
   "description": "LiteRT-LM package",
   "publishConfig": {
     "access": "public"
@@ -45,8 +45,9 @@
   "devDependencies": {
     "@types/jasmine": "^5.1.8",
     "@webgpu/types": "^0.1.54",
-    "esbuild": "^0.23.0",
+    "esbuild": "^0.28.0",
     "eslint": "^9.8.0",
+    "https-proxy-agent": "^9.1.0",
     "jasmine": "^5.8.0",
     "jasmine-browser-runner": "^3.0.0",
     "jasmine-core": "^5.8.0",

--- a/js/packages/core/scripts/download-wasm.js
+++ b/js/packages/core/scripts/download-wasm.js
@@ -16,6 +16,7 @@ import fs from 'fs';
 import path from 'path';
 import https from 'https';
 import { fileURLToPath } from 'url';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -47,13 +48,38 @@ if (!fs.existsSync(destDir)) {
   fs.mkdirSync(destDir, { recursive: true });
 }
 
+// Node's built-in `https` module ignores HTTP_PROXY/HTTPS_PROXY env vars, so
+// corporate-proxy networks need an explicit proxy agent to reach the CDN.
+function getProxyAgent(hostname) {
+  const noProxy = (process.env.NO_PROXY || process.env.no_proxy || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const isBypassed = noProxy.some((pattern) =>
+    pattern === '*' ||
+    hostname === pattern ||
+    hostname.endsWith(pattern.startsWith('.') ? pattern : `.${pattern}`)
+  );
+  if (isBypassed) {
+    return undefined;
+  }
+
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+  return proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
+}
+
 function downloadFile(url, destPath, filename, redirectCount = 0) {
   if (redirectCount > 5) {
     console.error(`[Prebuild] Too many redirects for ${filename}`);
     return;
   }
 
-  https.get(url, (response) => {
+  const agent = getProxyAgent(new URL(url).hostname);
+  https.get(url, { agent }, (response) => {
     if (response.statusCode === 301 || response.statusCode === 302) {
       const redirectUrl = response.headers.location;
       downloadFile(redirectUrl, destPath, filename, redirectCount + 1);
@@ -80,7 +106,7 @@ function downloadFile(url, destPath, filename, redirectCount = 0) {
 }
 
 const checkUrl = `${cdnBaseUrl}/${files[0]}`;
-const req = https.request(checkUrl, { method: 'HEAD' }, (res) => {
+const req = https.request(checkUrl, { method: 'HEAD', agent: getProxyAgent(new URL(checkUrl).hostname) }, (res) => {
   res.resume();
   if (res.statusCode === 404) {
     console.log(`[Prebuild] Version ${version} not available on CDN yet, skipping download.`);

--- a/js/turbo.json
+++ b/js/turbo.json
@@ -1,13 +1,22 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["SKIP_WASM_DOWNLOAD"],
+  "globalPassThroughEnv": [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy"
+  ],
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**"],
+      "outputs": ["dist/**", "wasm/**"],
       "dependsOn": ["^build"]
     },
     "dev": {
+      "outputs": ["dist/**", "wasm/**"],
       "persistent": true,
       "dependsOn": ["build"]
     },


### PR DESCRIPTION
Node's https module and Turborepo's strict envMode both ignore HTTP(S)_PROXY, so WASM downloads timed out behind a corporate proxy; route them through https-proxy-agent and pass the proxy env vars through turbo. Also fix an npm-run-dev restart loop caused by the js/ workspace having no .gitignore (turbo was treating dist/node_modules/ wasm as watched source inputs), replace the bash-only copy-wasm script with a cross-platform Node version so it works under Windows cmd.exe, and bump @litert-lm/core to 0.15.0 since 0.12.1's published WASM binary predates the enableBenchmark binding the TS source calls (0.16.0 is also unusable — its npm publish ships no build artifacts).