### PR TITLE
swift: Add public `close()` to `Conversation` for deterministic session release

### DIFF
--- a/swift/Conversation.swift
+++ b/swift/Conversation.swift
@@ -50,6 +50,9 @@ private let recurringToolCallLimit = 25
 /// for try await chunk in conversation.sendMessageStream(Message("Hello world")) {
 ///   print(chunk.text)
 /// }
+///
+/// // Close the conversation at the end to release the underlying native session.
+/// conversation.close()
 /// ```
 ///
 /// This class facilitates interaction with the LiteRT-LM model by handling message sending
@@ -85,6 +88,22 @@ public class Conversation {
   }
 
   deinit {
+    if let handle = handle {
+      self.handle = nil
+      litert_lm_conversation_delete(handle)
+    }
+  }
+
+  /// Releases the underlying native session synchronously.
+  ///
+  /// The engine supports only one session at a time, so call this when the conversation is no
+  /// longer needed to guarantee that a subsequent `Engine.createConversation` succeeds, instead
+  /// of relying on ARC to run `deinit` at a non-deterministic time. If an inference is still in
+  /// progress, call `cancel()` first.
+  ///
+  /// After closing, `isAlive` returns `false` and methods that require a live session throw
+  /// `LiteRTLMError.conversation(.notAlive)`. Calling `close()` again is a no-op.
+  public func close() {
     if let handle = handle {
       self.handle = nil
       litert_lm_conversation_delete(handle)

--- a/swift/ConversationTests.swift
+++ b/swift/ConversationTests.swift
@@ -527,4 +527,38 @@ class ConversationTests: XCTestCase {
     // and then releases localEngine, triggering Engine.deinit, setting handle = nil before litert_lm_engine_delete without crashing.
     localConversation = nil
   }
+
+  func testCloseReleasesNativeSessionAndAllowsNewConversation() async throws {
+    let conversation = try await self.engine.createConversation(with: ConversationConfig())
+    XCTAssertTrue(conversation.isAlive)
+
+    conversation.close()
+    XCTAssertFalse(conversation.isAlive)
+
+    // The native session is released deterministically, so the same engine can create a new
+    // conversation without waiting for ARC to deallocate the closed one.
+    let newConversation = try await self.engine.createConversation(with: ConversationConfig())
+    XCTAssertTrue(newConversation.isAlive)
+  }
+
+  func testCloseIsIdempotent() async throws {
+    let conversation = try await self.engine.createConversation(with: ConversationConfig())
+    XCTAssertTrue(conversation.isAlive)
+
+    conversation.close()
+    conversation.close()
+    XCTAssertFalse(conversation.isAlive)
+  }
+
+  func testSendMessageAfterCloseThrowsNotAlive() async throws {
+    let conversation = try await self.engine.createConversation(with: ConversationConfig())
+    conversation.close()
+
+    do {
+      _ = try await conversation.sendMessage(Message("Hello"))
+      XCTFail("Expected notAlive error to be thrown")
+    } catch let error as LiteRTLMError {
+      XCTAssertEqual(error, LiteRTLMError.conversation(.notAlive))
+    }
+  }
 }


### PR DESCRIPTION
Fixes #2589.

This adds a public `close()` to the Swift `Conversation`, mirroring Kotlin's `Conversation.close()`. It deletes the native session synchronously, so `isAlive` becomes `false` immediately and a subsequent `engine.createConversation()` no longer races ARC.

Background: the native session was released only in `deinit`. Because the engine supports one session at a time, dropping the Swift reference and creating a new conversation could intermittently fail with `FAILED_PRECONDITION: A session already exists` until ARC happened to deallocate the old instance — repro details in #2589.

The change (+53 lines, `swift/` only):

- `Conversation.close()` clears the handle, then calls `litert_lm_conversation_delete` — the same order `deinit` already uses. `deinit` stays as a safety net and becomes a no-op once the handle is cleared.
- The class doc example now ends with `conversation.close()`, matching the Kotlin docs.
- Three tests in `ConversationTests.swift`: `close()` releases the session so the same engine can create a new conversation; a second `close()` is a no-op; `sendMessage` after `close()` throws `LiteRTLMError.conversation(.notAlive)`.

One deliberate difference from Kotlin: there a second `close()` throws `IllegalStateException`; here it is a no-op, which is what #2589 asks for and lets callers put `close()` in a `defer` without guarding. Happy to switch to the Kotlin throwing semantics if you prefer the bindings to match.

Thanks for considering — glad to reshape any of this into whatever form is easiest to import.
