### PR TITLE
docs(kotlin): note the Kotlin version the published litertlm-android AAR requires (0.17.0 = Kotlin 2.4)

### DIFF
--- a/docs/api/kotlin/getting_started.md
+++ b/docs/api/kotlin/getting_started.md
@@ -69,6 +69,12 @@ and
 
 `latest.release` can be used to get the latest release.
 
+The published packages are built with a current Kotlin release, so the consuming
+project needs a matching Kotlin Gradle plugin: `litertlm-android` 0.17.0 carries
+Kotlin metadata 2.4.0 and needs Kotlin 2.4 or newer (a 2.2.x compiler stops with
+`The actual metadata version is 2.4.0, but the compiler version 2.2.0 can read
+versions up to 2.3.0`); 0.16.1 needed Kotlin 2.2.
+
 ### 2. Initialize the Engine
 
 The `Engine` is the entry point to the API. Initialize it with the model path


### PR DESCRIPTION
Thanks for shipping 0.17.0 to Google Maven the same day as PyPI — the AAR resolves cleanly and runs fine once the toolchain matches.

I keep a small install-and-generate check for the Android artifact, and this release moved the consumer floor: `litertlm-android:0.17.0` carries Kotlin metadata 2.4.0 (and pulls kotlin-stdlib / kotlin-reflect 2.4.0), so a project on Kotlin 2.2.10 now stops at `compileDebugAndroidTestKotlin` with `The actual metadata version is 2.4.0, but the compiler version 2.2.0 can read versions up to 2.3.0`. The same project builds and runs on a Pixel 8a with Kotlin 2.4.0 (and Gradle 8.14.4, which KGP 2.4 requires). 0.16.1 needed Kotlin 2.2 (metadata 2.3.0).

Kotlin 2.4 is a public stable release, so nothing is wrong with the artifact; the gap is that the Gradle section of the Kotlin guide does not state a minimum Kotlin version, and the failure surfaces as a metadata error deep in the build. This adds one paragraph under the Gradle dependency block with the 0.17.0 and 0.16.1 figures. Happy to move it or reword it to match how you track toolchain requirements.
