### PR TITLE
Fix context rewind during text scoring

### DIFF
--- a/python/litert_lm/engine_test.py
+++ b/python/litert_lm/engine_test.py
@@ -677,6 +677,40 @@ class EngineTest(LiteRtLmTestBase):
       for score in scoring_responses.token_scores[0]:
         self.assertIsInstance(score, float)
 
+  @parameterized.parameters(
+      ("Hello", " world", " again"),
+      ("The", " sky", " is blue"),
+      ("The capital of France", " is", " Paris"),
+  )
+  def test_session_api_scoring_matches_prefill(self, prefix, middle, target):
+    with self._create_engine(max_num_tokens=32) as engine:
+      prefix_ids = engine.tokenize(prefix)
+      middle_ids = engine.tokenize(middle)
+      target_ids = engine.tokenize(target)
+      self.assertEqual(
+          engine.tokenize(prefix + middle), prefix_ids + middle_ids
+      )
+      self.assertEqual(
+          engine.tokenize(middle + target), middle_ids + target_ids
+      )
+
+      with engine.create_session(apply_prompt_template=False) as session:
+        session.run_prefill([prefix])
+        responses = session.run_text_scoring([middle + target])
+        expected_scores = responses.token_scores[0][len(middle_ids) :]
+      self.assertLen(expected_scores, len(target_ids))
+
+      # Moving context from scoring to prefill must preserve the target scores.
+      for context in ([prefix + middle], [prefix, middle]):
+        with self.subTest(context=context):
+          with engine.create_session(apply_prompt_template=False) as session:
+            for text in context:
+              session.run_prefill([text])
+            responses = session.run_text_scoring([target])
+          self.assertSequenceAlmostEqual(
+              responses.token_scores[0], expected_scores, places=5
+          )
+
   def test_session_api_run_text_scoring_no_token_lengths(self):
     with (
         self._create_engine() as engine,

--- a/runtime/framework/resource_management/resource_manager.cc
+++ b/runtime/framework/resource_management/resource_manager.cc
@@ -353,17 +353,7 @@ class LockedLlmExecutor : public LlmExecutor {
 
   absl::StatusOr<TensorBuffer> DecodeLogits(
       const ExecutorInputs& inputs) override {
-    ABSL_ASSIGN_OR_RETURN(int current_step, llm_executor_->GetCurrentStep());
-    ABSL_ASSIGN_OR_RETURN(const ProcessedTokens* processed_tokens,
-                          llm_executor_->GetProcessedTokens());
-    // If the current step is pointing at right after the pending token, set
-    // the current step to the previous step. This ensures that the current
-    // step points to the token to be processed, as expected by
-    // llm_executor_->DecodeLogits().
-    if (current_step == processed_tokens->TokenCount() &&
-        !processed_tokens->GetNextUnprocessedToken().token.empty()) {
-      ABSL_RETURN_IF_ERROR(llm_executor_->SetCurrentStep(current_step - 1));
-    }
+    // The executor already accounts for the pending token's position.
     ABSL_RETURN_IF_ERROR(MaybeTruncateProcessedTokens());
     return llm_executor_->DecodeLogits(inputs);
   }


### PR DESCRIPTION
Text scoring rewinds the decode position twice after prefill, overwriting the preceding KV-cache position and producing incorrect log probabilities. Remove the extra rewind in `LockedLlmExecutor::DecodeLogits()`; the executor already handles the pending token's position.

Fixes #3561.

Add regression coverage verifying that moving context between prefill and scoring preserves target scores, including split prefill. All six comparisons fail with the original implementation and pass with this change.

Validation on Linux ARM64: 417 cases across 14 existing test targets pass. Also verified the compiled runtime through quant-drift with Gemma 3, Gemma 4 and Qwen on CPU, and Llama on GPU.
