### PR TITLE
Use explicit LFS endpoint for SwiftPM checkouts

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+    url = https://github.com/google-ai-edge/LiteRT-LM.git/info/lfs


### PR DESCRIPTION
Swift Package Manager creates dependency checkouts from a local repository mirror, so Git LFS can resolve the checkout's remote to that mirror and report `remote missing object` for objects that are available on GitHub. 

This PR adds a repository-level `.lfsconfig` pointing to LiteRT-LM's GitHub LFS endpoint so those checkouts fetch objects from the original host.

This fix addresses the local-mirror failure described in #2407. LFS downloads remain enabled, including platform binaries that SwiftPM doesn't use. The explicit endpoint also applies to LFS pushes, so contributors pushing to forks need to override `lfs.url` with their fork's endpoint.
